### PR TITLE
Stream visualize_hits.py CSV loading through polars instead of loading it into memory

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -66,6 +66,7 @@ dependencies:
   - pillow=11.1.0=py312h80c1187_0
   - pip=25.0=pyh8b19718_0
   - pluggy=1.5.0=pyhd8ed1ab_1
+  - polars=1.34.0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - pycparser=2.22=pyh29332c3_1
   - pyparsing=3.2.1=pyhd8ed1ab_0

--- a/environment_mac_arm64.yml
+++ b/environment_mac_arm64.yml
@@ -58,6 +58,7 @@ dependencies:
   - pillow
   - pip
   - pluggy
+  - polars
   - pthread-stubs
   - pycparser
   - pyparsing

--- a/environment_no_versions.yml
+++ b/environment_no_versions.yml
@@ -66,6 +66,7 @@ dependencies:
   - pillow
   - pip
   - pluggy
+  - polars
   - pthread-stubs
   - pycparser
   - pyparsing

--- a/scripts/visualize_hits.py
+++ b/scripts/visualize_hits.py
@@ -20,13 +20,13 @@ Usage:
 """
 
 import argparse
-import csv
 import os
 import re
 import textwrap
 from collections import defaultdict
 
 import matplotlib
+import polars as pl
 
 matplotlib.use("Agg")
 # Keep SVG text as real <text> elements (selectable/copyable), not vector outlines.
@@ -120,9 +120,40 @@ def resolve_query_names(query_name_arg, all_query_names):
     return sorted(set(matches))
 
 
-def load_rows(csv_path):
-    with open(csv_path, newline="") as fh:
-        return list(csv.DictReader(fh))
+def scan_csv(csv_path):
+    """Open the results CSV lazily -- nothing is read off disk until a query
+    is `.collect()`-ed, so the whole file never has to fit in memory at once.
+    infer_schema_length=None scans every row for dtypes up front, since a
+    poisson_pvalue column of mostly-0 values with rare 1e-300-style outliers
+    further down the file could otherwise get mis-inferred as a narrower type."""
+    return pl.scan_csv(csv_path, infer_schema_length=None)
+
+
+def load_query_names(lazy_rows):
+    """Every distinct query_name in the CSV. Only the query_name column is
+    read to compute this, not the whole (much wider) row."""
+    return set(lazy_rows.select("query_name").unique().collect().get_column("query_name"))
+
+
+def load_rows_for_queries(lazy_rows, query_names):
+    """Collect only the rows belonging to query_names, in one pass. Filtering
+    happens before collecting, so the common `--query-name` case (a small
+    subset) never materializes the rest of the CSV."""
+    return lazy_rows.filter(pl.col("query_name").is_in(list(query_names))).collect()
+
+
+def iter_query_rows(df):
+    """Yield (query_name, rows) one query at a time -- rows as plain dicts,
+    matching the shape the rest of this module already expects from
+    csv.DictReader. A single grouped pass over the collected DataFrame, so
+    only one query's rows are ever converted to Python dicts at a time,
+    instead of the whole result up front (partition_by(as_dict=True) does
+    that eagerly, roughly doubling peak memory for a "plot every query" run).
+    Re-filtering the DataFrame once per query instead of grouping would avoid
+    that too, but stays O(queries x rows) -- no better than the old
+    pure-Python approach once more than a handful of queries are requested."""
+    for (query_name,), group in df.group_by("query_name", maintain_order=True):
+        yield query_name, group.to_dicts()
 
 
 def merge_regions_by_target(rows, gap_merge):
@@ -532,22 +563,19 @@ def main():
     os.makedirs(args.output_dir, exist_ok=True)
 
     lengths = read_fasta_lengths(args.query_fasta)
-    rows = load_rows(args.csv)
+    lazy_rows = scan_csv(args.csv)
 
-    all_query_names = {r["query_name"] for r in rows}
+    all_query_names = load_query_names(lazy_rows)
     query_names = resolve_query_names(args.query_name, all_query_names)
     if args.query_name is not None and not query_names:
         available = ", ".join(sorted(short_label(n) for n in all_query_names))
         print(f"No query matching '{args.query_name}' found in {args.csv}. Available: {available}")
         return
 
-    for query_name in query_names:
+    df = load_rows_for_queries(lazy_rows, query_names)
+    for query_name, query_rows in iter_query_rows(df):
         if query_name not in lengths:
             print(f"Skipping '{query_name}': not found in {args.query_fasta}")
-            continue
-        query_rows = [r for r in rows if r["query_name"] == query_name]
-        if not query_rows:
-            print(f"Skipping '{query_name}': no hits in {args.csv}")
             continue
         _render_query(query_name, query_rows, lengths[query_name], args)
 


### PR DESCRIPTION
## Summary
- `load_rows()` used to read the entire results CSV into a `list` of `csv.DictReader` row-dicts, then re-filter that list once per query -- O(queries × rows), holding every row for every query in memory regardless of how many genes were actually being plotted.
- Now the CSV is opened as a `polars` `LazyFrame`. The `--query-name` filter is pushed down *before* collecting, so the common single-gene case never materializes the rest of the file. The "plot every query" default (no `--query-name`) still collects the file once (not once per query) and groups it in a single pass instead of a per-query Python-level scan.
- Added `polars` to `environment.yml`, `environment_no_versions.yml`, `environment_mac_arm64.yml`.

## Benchmark

Synthetic proteome-scale result CSVs, `kmerseek-dev` conda env, macOS, peak RSS via `/usr/bin/time -l`:

| Scenario | File | Before (peak mem / time) | After (peak mem / time) |
|---|---|---|---|
| Single gene (`--query-name`) | 94MB / 300k rows / 10k queries | 460MB / 0.80s | **168MB (2.7x less)** / 0.59s |
| Every query (default) | 28MB / 90k rows / 6k queries | 144MB / 38.15s | 202MB (higher) / **1.25s (30x faster)** |
| Every query (default) | 94MB / 300k rows / 10k queries | did not finish in 2 min | 397MB / 3.09s |

Takeaways:
- The **single-gene case** (the typical CLI usage, `--query-name CED9`) is the big win on both axes: filtering happens before the file is materialized, so memory scales with the query's own rows, not the whole CSV.
- The **"plot every query" case** trades a bit of peak memory (polars runtime + collecting the whole frame once) for a large speedup, because the old code's per-query `[r for r in rows if ...]` was O(queries × rows) in pure Python -- it doesn't just use more memory, it doesn't finish at all past a few thousand queries.

## Test plan
- [x] `pytest scripts/test_visualize_hits.py` -- 50/50 passing, unchanged behavior
- [x] Verified benchmark numbers against the actual shipped `visualize_hits.py` functions (not a standalone copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)