### PR TITLE
Log k-mer frequency histogram and top/bottom 10 k-mers during indexing

### DIFF
--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -426,10 +426,7 @@ impl ProteomeIndex {
         path: &Path,
         kmer_frequencies: &HashMap<u64, usize>,
     ) -> IndexResult<()> {
-        let mut spectrum: BTreeMap<usize, usize> = BTreeMap::new();
-        for &count in kmer_frequencies.values() {
-            *spectrum.entry(count).or_insert(0) += 1;
-        }
+        let spectrum = Self::frequency_spectrum(kmer_frequencies);
 
         let file = File::create(path)?;
         let mut sink: Box<dyn Write> = if path.extension().is_some_and(|e| e == "gz") {
@@ -442,10 +439,13 @@ impl ProteomeIndex {
         // for the whole file and would otherwise be repeated on every row. Readers skip it
         // with a comment prefix, e.g. polars' `read_csv(..., comment_prefix="#")`.
         let total: usize = kmer_frequencies.values().sum();
+        let unique = kmer_frequencies.len();
         writeln!(
             sink,
-            "# total_kmers={total} unique_kmers={} moltype={} ksize={}",
-            kmer_frequencies.len(),
+            "# total_kmers={total} unique_kmers={unique} mean_seqs_per_kmer={:.4} \
+             median_seqs_per_kmer={:.1} moltype={} ksize={}",
+            total as f64 / unique as f64,
+            Self::median_occurrences(&spectrum, unique),
             self.moltype,
             self.ksize,
         )?;
@@ -483,6 +483,41 @@ impl ProteomeIndex {
         bins
     }
 
+    /// Exact frequency spectrum: occurrence count -> how many k-mers were seen that many times.
+    ///
+    /// Distinct from [`frequency_bins`], which buckets into powers of two for display. This
+    /// keeps every count so order statistics stay exact.
+    fn frequency_spectrum(kmer_frequencies: &HashMap<u64, usize>) -> BTreeMap<usize, usize> {
+        let mut spectrum: BTreeMap<usize, usize> = BTreeMap::new();
+        for &count in kmer_frequencies.values() {
+            *spectrum.entry(count).or_insert(0) += 1;
+        }
+        spectrum
+    }
+
+    /// Median occurrences per k-mer, averaging the two middle values when the count is even.
+    ///
+    /// WHY alongside the mean: these distributions are heavily right-skewed, so a handful of
+    /// very common k-mers drag the mean well above what a typical k-mer looks like.
+    fn median_occurrences(spectrum: &BTreeMap<usize, usize>, unique: usize) -> f64 {
+        if unique == 0 {
+            return 0.0;
+        }
+        // Positions of the middle element(s) in the sorted list of per-k-mer counts.
+        let (lower_rank, upper_rank) = ((unique - 1) / 2, unique / 2);
+        let (mut seen, mut lower) = (0usize, None);
+        for (&occurrences, &n_kmers) in spectrum {
+            seen += n_kmers;
+            if lower.is_none() && seen > lower_rank {
+                lower = Some(occurrences);
+            }
+            if seen > upper_rank {
+                return (lower.unwrap_or(occurrences) + occurrences) as f64 / 2.0;
+            }
+        }
+        lower.unwrap_or(0) as f64
+    }
+
     /// Print the binned frequency distribution as an ASCII bar chart.
     ///
     /// Empty bins between the smallest and largest populated bin are printed with a zero count
@@ -497,10 +532,12 @@ impl ProteomeIndex {
         // of (sequence, k-mer) pairs the index holds rather than a count of k-mer positions.
         let total: usize = kmer_frequencies.values().sum();
         let unique = kmer_frequencies.len();
+        let median = Self::median_occurrences(&Self::frequency_spectrum(kmer_frequencies), unique);
         eprintln!(
             "[save] K-mer frequency histogram: {total} total k-mers found, {unique} unique \
-             (mean {:.2} sequences per k-mer)",
+             (mean {:.2}, median {:.1} sequences per k-mer)",
             total as f64 / unique as f64,
+            median,
         );
         for bin in first..=last {
             let count = bins.get(&bin).copied().unwrap_or(0);
@@ -2897,12 +2934,31 @@ mod tests {
 
         assert_eq!(
             contents,
-            "# total_kmers=8 unique_kmers=5 moltype=protein ksize=10\n\
+            "# total_kmers=8 unique_kmers=5 mean_seqs_per_kmer=1.6000 median_seqs_per_kmer=1.0 moltype=protein ksize=10\n\
              moltype,ksize,occurrences,n_kmers\n\
              protein,10,1,3\n\
              protein,10,2,1\n\
              protein,10,3,1\n"
         );
+    }
+
+    #[test]
+    fn test_median_occurrences_exact() {
+        // Counts 1,1,1,2,3 -> odd length, middle element is 1.
+        let odd: BTreeMap<usize, usize> = [(1, 3), (2, 1), (3, 1)].into_iter().collect();
+        assert_eq!(ProteomeIndex::median_occurrences(&odd, 5), 1.0);
+
+        // Counts 1,1,2,3 -> even length, middle two are 1 and 2.
+        let even: BTreeMap<usize, usize> = [(1, 2), (2, 1), (3, 1)].into_iter().collect();
+        assert_eq!(ProteomeIndex::median_occurrences(&even, 4), 1.5);
+
+        // Counts 4,4,9,9 -> both middles inside one bucket.
+        let flat: BTreeMap<usize, usize> = [(4, 2), (9, 2)].into_iter().collect();
+        assert_eq!(ProteomeIndex::median_occurrences(&flat, 4), 6.5);
+
+        // Single value and empty.
+        assert_eq!(ProteomeIndex::median_occurrences(&[(7, 1)].into_iter().collect(), 1), 7.0);
+        assert_eq!(ProteomeIndex::median_occurrences(&BTreeMap::new(), 0), 0.0);
     }
 
     #[test]

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -330,7 +330,7 @@ impl ProteomeIndex {
             inverted_index.len(),
         );
 
-        Self::log_kmer_frequency_stats(&kmer_frequencies);
+        self.log_kmer_frequency_stats(&kmer_frequencies, &inverted_index, &target_list);
 
         // Serialize and store the search cache
         eprintln!(
@@ -357,7 +357,14 @@ impl ProteomeIndex {
     ///
     /// Bins are power-of-two ranges (1, 2-3, 4-7, ...) since k-mer frequency distributions
     /// are typically heavily right-skewed (most k-mers occur once, a few occur very often).
-    fn log_kmer_frequency_stats(kmer_frequencies: &HashMap<u64, usize>) {
+    /// The top/bottom lists show the actual encoded k-mer string (not the hash), resolved by
+    /// looking up one signature that contains each hash via the inverted index.
+    fn log_kmer_frequency_stats(
+        &self,
+        kmer_frequencies: &HashMap<u64, usize>,
+        inverted_index: &HashMap<u64, Vec<u32>>,
+        target_list: &[String],
+    ) {
         if kmer_frequencies.is_empty() {
             return;
         }
@@ -383,15 +390,41 @@ impl ProteomeIndex {
         let mut by_frequency: Vec<(&u64, &usize)> = kmer_frequencies.iter().collect();
         by_frequency.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
 
-        eprintln!("[save] Top 10 most common k-mers (hash: occurrences):");
+        eprintln!("[save] Top 10 most common k-mers (encoded k-mer: occurrences):");
         for (hash, count) in by_frequency.iter().take(10) {
-            eprintln!("[save]   {hash}: {count}");
+            let kmer = self.resolve_kmer_string(**hash, inverted_index, target_list);
+            eprintln!("[save]   {kmer}: {count}");
         }
 
-        eprintln!("[save] Bottom 10 least common k-mers (hash: occurrences):");
+        eprintln!("[save] Bottom 10 least common k-mers (encoded k-mer: occurrences):");
         for (hash, count) in by_frequency.iter().rev().take(10) {
-            eprintln!("[save]   {hash}: {count}");
+            let kmer = self.resolve_kmer_string(**hash, inverted_index, target_list);
+            eprintln!("[save]   {kmer}: {count}");
         }
+    }
+
+    /// Resolve one k-mer hash back to the actual encoded k-mer string it was hashed from,
+    /// by finding a signature that contains it (via the inverted index) and slicing that
+    /// signature's stored sequence at the recorded position.
+    ///
+    /// WHY: hashes are one-way (murmur), so the only way to recover the k-mer text is to
+    /// look up where it occurred in a sequence we already have in memory.
+    fn resolve_kmer_string(
+        &self,
+        hash: u64,
+        inverted_index: &HashMap<u64, Vec<u32>>,
+        target_list: &[String],
+    ) -> String {
+        let ksize = self.ksize as usize;
+        (|| {
+            let target_idx = *inverted_index.get(&hash)?.first()?;
+            let md5 = target_list.get(target_idx as usize)?;
+            let sig = self.signatures.get(md5)?;
+            let position = *sig.kmer_positions().get(&hash)?.first()?;
+            let seq = sig.get_moltype_sequence().or_else(|| sig.get_raw_sequence())?;
+            seq.get(position..position + ksize).map(str::to_string)
+        })()
+        .unwrap_or_else(|| format!("<sequence unavailable, hash {hash}>"))
     }
 
     /// Save the current index state to RocksDB using chunked storage format

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -2,10 +2,14 @@ use dashmap::DashMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use rocksdb::{Options, DB};
 use serde::{Deserialize, Serialize};
 use sourmash::_hash_murmur;
@@ -29,7 +33,7 @@ use crate::sketch::{ProteinSketch, ProteinSketchStore};
 /// (e.g. new fields in SearchCache, renamed fields in ProteinSketchStore, etc.).
 /// Indices that predate versioning (schema_version key absent) are treated as version 0
 /// and will be rejected with a clear error message asking the user to rebuild.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Statistics for k-mer frequency analysis
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -284,7 +288,7 @@ impl ProteomeIndex {
     /// (every time) avoids the need to load all 200k+ signatures into memory before searching.
     /// During search, only candidate signatures (those sharing ≥1 k-mer with the query) are
     /// loaded on-demand from RocksDB, reducing startup time from minutes to seconds.
-    fn save_inverted_index(&self) -> IndexResult<()> {
+    fn save_inverted_index(&self, kmer_stats_out: Option<&Path>) -> IndexResult<()> {
         let t0 = Instant::now();
         let total_sigs = self.signatures.len();
         eprintln!("[save] Building inverted index for {} signatures...", total_sigs);
@@ -330,7 +334,12 @@ impl ProteomeIndex {
             inverted_index.len(),
         );
 
-        self.log_kmer_frequency_stats(&kmer_frequencies, &inverted_index, &target_list);
+        self.log_kmer_frequency_stats(
+            &kmer_frequencies,
+            &inverted_index,
+            &target_list,
+            kmer_stats_out,
+        )?;
 
         // Serialize and store the search cache
         eprintln!(
@@ -365,17 +374,21 @@ impl ProteomeIndex {
         kmer_frequencies: &HashMap<u64, usize>,
         inverted_index: &HashMap<u64, Vec<u32>>,
         target_list: &[String],
-    ) {
+        kmer_stats_out: Option<&Path>,
+    ) -> IndexResult<()> {
         if kmer_frequencies.is_empty() {
-            return;
+            return Ok(());
         }
         Self::print_frequency_histogram(kmer_frequencies);
+        if let Some(path) = kmer_stats_out {
+            self.write_kmer_frequency_spectrum(path, kmer_frequencies)?;
+        }
 
         // Resolving a hash back to text needs the sequence it came from, which is only in
         // memory when the index was built with store_raw_sequences.
         if !self.has_stored_sequences() {
             eprintln!("[save] (k-mer sequences not stored, skipping most/least common k-mers)");
-            return;
+            return Ok(());
         }
 
         let n = Self::KMER_EXAMPLES;
@@ -398,6 +411,50 @@ impl ProteomeIndex {
             inverted_index,
             target_list,
         );
+        Ok(())
+    }
+
+    /// Write the k-mer frequency spectrum (occurrences -> how many k-mers had that many)
+    /// as CSV, gzip-compressed when the path ends in `.gz`.
+    ///
+    /// WHY the spectrum rather than one row per k-mer: this is the distribution you plot, and
+    /// it is a few thousand rows instead of tens of millions, so a sweep over alphabets and
+    /// k-sizes stays small. `moltype` and `ksize` are repeated on every row so that files from
+    /// different runs concatenate directly into one frame.
+    fn write_kmer_frequency_spectrum(
+        &self,
+        path: &Path,
+        kmer_frequencies: &HashMap<u64, usize>,
+    ) -> IndexResult<()> {
+        let mut spectrum: BTreeMap<usize, usize> = BTreeMap::new();
+        for &count in kmer_frequencies.values() {
+            *spectrum.entry(count).or_insert(0) += 1;
+        }
+
+        let file = File::create(path)?;
+        let sink: Box<dyn Write> = if path.extension().is_some_and(|e| e == "gz") {
+            Box::new(GzEncoder::new(file, Compression::default()))
+        } else {
+            Box::new(file)
+        };
+        let mut writer = csv::Writer::from_writer(sink);
+        writer.write_record(["moltype", "ksize", "occurrences", "n_kmers"])?;
+        let ksize = self.ksize.to_string();
+        for (occurrences, n_kmers) in &spectrum {
+            writer.write_record([
+                &self.moltype,
+                &ksize,
+                &occurrences.to_string(),
+                &n_kmers.to_string(),
+            ])?;
+        }
+        writer.flush()?;
+        eprintln!(
+            "[save] Wrote k-mer frequency spectrum ({} rows) to {}",
+            spectrum.len(),
+            path.display()
+        );
+        Ok(())
     }
 
     /// Bin k-mer counts into power-of-two ranges: bin `b` holds counts in `[2^b, 2^(b+1))`.
@@ -538,6 +595,12 @@ impl ProteomeIndex {
     }
 
     pub fn save_state(&self) -> IndexResult<()> {
+        self.save_state_with_kmer_stats(None)
+    }
+
+    /// Like [`save_state`], but also writes the k-mer frequency spectrum to `kmer_stats_out`
+    /// as CSV (gzipped when the path ends in `.gz`) for plotting across alphabets and k-sizes.
+    pub fn save_state_with_kmer_stats(&self, kmer_stats_out: Option<&Path>) -> IndexResult<()> {
         let t_start = Instant::now();
         eprintln!("[save] save_state() started ({} signatures in memory)", self.signatures.len());
 
@@ -630,7 +693,7 @@ impl ProteomeIndex {
         // Build and persist search cache + individual signatures for fast search startup
         eprintln!("[save] Building search cache...");
         let t4 = Instant::now();
-        self.save_inverted_index()?;
+        self.save_inverted_index(kmer_stats_out)?;
         eprintln!("[save] Search cache saved in {:.1}s", t4.elapsed().as_secs_f32());
 
         // Flush to ensure data is written to disk

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -353,12 +353,13 @@ impl ProteomeIndex {
         Ok(())
     }
 
-    /// Log a k-mer frequency histogram and the top/bottom 10 k-mers by frequency to stderr.
+    /// Number of k-mers listed in the "most common" / "least common" summaries.
+    const KMER_EXAMPLES: usize = 10;
+
+    /// Log a k-mer frequency histogram and the most/least common k-mers to stderr.
     ///
-    /// Bins are power-of-two ranges (1, 2-3, 4-7, ...) since k-mer frequency distributions
-    /// are typically heavily right-skewed (most k-mers occur once, a few occur very often).
-    /// The top/bottom lists show the actual encoded k-mer string (not the hash), resolved by
-    /// looking up one signature that contains each hash via the inverted index.
+    /// The lists show the actual encoded k-mer string (not the hash), resolved by looking up
+    /// one signature that contains each hash via the inverted index.
     fn log_kmer_frequency_stats(
         &self,
         kmer_frequencies: &HashMap<u64, usize>,
@@ -368,39 +369,123 @@ impl ProteomeIndex {
         if kmer_frequencies.is_empty() {
             return;
         }
+        Self::print_frequency_histogram(kmer_frequencies);
 
+        // Resolving a hash back to text needs the sequence it came from, which is only in
+        // memory when the index was built with store_raw_sequences.
+        if !self.has_stored_sequences() {
+            eprintln!("[save] (k-mer sequences not stored, skipping most/least common k-mers)");
+            return;
+        }
+
+        let n = Self::KMER_EXAMPLES;
+        let most = Self::n_smallest_by_key(kmer_frequencies, n, |hash, count| {
+            (std::cmp::Reverse(count), hash)
+        });
+        let least = Self::n_smallest_by_key(kmer_frequencies, n, |hash, count| (count, hash));
+
+        self.print_kmer_examples(
+            "most common",
+            &most,
+            kmer_frequencies,
+            inverted_index,
+            target_list,
+        );
+        self.print_kmer_examples(
+            "least common",
+            &least,
+            kmer_frequencies,
+            inverted_index,
+            target_list,
+        );
+    }
+
+    /// Bin k-mer counts into power-of-two ranges: bin `b` holds counts in `[2^b, 2^(b+1))`.
+    ///
+    /// WHY power-of-two: k-mer frequency distributions are heavily right-skewed (most k-mers
+    /// occur once, a few occur thousands of times), so linear bins would be nearly unreadable.
+    fn frequency_bins(kmer_frequencies: &HashMap<u64, usize>) -> BTreeMap<u32, usize> {
         let mut bins: BTreeMap<u32, usize> = BTreeMap::new();
         for &freq in kmer_frequencies.values() {
             let bin = usize::BITS - freq.leading_zeros() - 1;
             *bins.entry(bin).or_insert(0) += 1;
         }
+        bins
+    }
+
+    /// Print the binned frequency distribution as an ASCII bar chart.
+    ///
+    /// Empty bins between the smallest and largest populated bin are printed with a zero count
+    /// so that gaps in the distribution are explicit rather than silently skipped.
+    fn print_frequency_histogram(kmer_frequencies: &HashMap<u64, usize>) {
+        const BAR_WIDTH: usize = 40;
+        let bins = Self::frequency_bins(kmer_frequencies);
+        let (&first, &last) = (bins.keys().next().unwrap(), bins.keys().next_back().unwrap());
+        let max_count = *bins.values().max().unwrap();
 
         eprintln!("[save] K-mer frequency histogram ({} unique k-mers):", kmer_frequencies.len());
-        let max_count = *bins.values().max().unwrap();
-        const BAR_WIDTH: usize = 40;
-        for (bin, count) in &bins {
-            let lo = 1u64 << bin;
-            let hi = (1u64 << (bin + 1)) - 1;
+        for bin in first..=last {
+            let count = bins.get(&bin).copied().unwrap_or(0);
+            let (lo, hi) = (1u64 << bin, (1u64 << (bin + 1)) - 1);
             let label = if lo == hi { format!("{lo}") } else { format!("{lo}-{hi}") };
-            let bar_len = (count * BAR_WIDTH) / max_count;
-            let bar = "#".repeat(bar_len.max(1));
+            let bar = "#".repeat((count * BAR_WIDTH / max_count).max(usize::from(count > 0)));
             eprintln!("[save]   {label:>12} occurrences: {count:>10} k-mers  {bar}");
         }
+    }
 
-        let mut by_frequency: Vec<(&u64, &usize)> = kmer_frequencies.iter().collect();
-        by_frequency.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    /// Return the `n` (hash, count) pairs with the smallest `key`, in ascending key order.
+    ///
+    /// WHY a bounded heap instead of sorting: real proteome indexes hold tens of millions of
+    /// unique k-mers, so materializing and sorting the whole list just to read off 10 entries
+    /// would cost seconds and hundreds of MB. This is O(N log n) time and O(n) memory.
+    fn n_smallest_by_key<K: Ord>(
+        kmer_frequencies: &HashMap<u64, usize>,
+        n: usize,
+        key: impl Fn(u64, usize) -> K,
+    ) -> Vec<(u64, usize)> {
+        let mut heap: BinaryHeap<(K, u64, usize)> = BinaryHeap::with_capacity(n + 1);
+        for (&hash, &count) in kmer_frequencies {
+            heap.push((key(hash, count), hash, count));
+            if heap.len() > n {
+                heap.pop();
+            }
+        }
+        let mut selected = heap.into_vec();
+        selected.sort();
+        selected.into_iter().map(|(_, hash, count)| (hash, count)).collect()
+    }
 
-        eprintln!("[save] Top 10 most common k-mers (encoded k-mer: occurrences):");
-        for (hash, count) in by_frequency.iter().take(10) {
-            let kmer = self.resolve_kmer_string(**hash, inverted_index, target_list);
+    /// Print one labelled list of example k-mers, noting how many share the boundary frequency.
+    ///
+    /// WHY the tie note: when hundreds of thousands of k-mers all occur once, listing ten of
+    /// them looks like a ranking but is really an arbitrary sample. Saying how many tie makes
+    /// that explicit.
+    fn print_kmer_examples(
+        &self,
+        label: &str,
+        examples: &[(u64, usize)],
+        kmer_frequencies: &HashMap<u64, usize>,
+        inverted_index: &HashMap<u64, Vec<u32>>,
+        target_list: &[String],
+    ) {
+        let Some(&(_, boundary)) = examples.last() else { return };
+        let tied = kmer_frequencies.values().filter(|&&c| c == boundary).count();
+        eprintln!("[save] {} {} k-mers (encoded k-mer: occurrences):", examples.len(), label);
+        for &(hash, count) in examples {
+            let kmer = self.resolve_kmer_string(hash, inverted_index, target_list);
             eprintln!("[save]   {kmer}: {count}");
         }
-
-        eprintln!("[save] Bottom 10 least common k-mers (encoded k-mer: occurrences):");
-        for (hash, count) in by_frequency.iter().rev().take(10) {
-            let kmer = self.resolve_kmer_string(**hash, inverted_index, target_list);
-            eprintln!("[save]   {kmer}: {count}");
+        if tied > examples.len() {
+            eprintln!("[save]   ({tied} k-mers occur {boundary}x; showing an arbitrary sample)");
         }
+    }
+
+    /// Whether signatures kept their sequence text, which `resolve_kmer_string` needs.
+    fn has_stored_sequences(&self) -> bool {
+        self.signatures
+            .iter()
+            .next()
+            .is_some_and(|s| s.get_moltype_sequence().is_some() || s.get_raw_sequence().is_some())
     }
 
     /// Resolve one k-mer hash back to the actual encoded k-mer string it was hashed from,
@@ -1550,7 +1635,7 @@ mod tests {
         TEST_FASTA_CONTENT, TEST_FASTA_GZ, TEST_FASTA_ZST, TEST_PROTEIN,
     };
     use crate::tests::test_utils::{self, print_kmer_positions};
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::path::PathBuf;
 
     /// Keeping the tests for ProteomeIndex in a separate file because they're more like integration tests
@@ -2702,6 +2787,95 @@ mod tests {
         let index3 =
             ProteomeIndex::new(temp_dir.path().join("test3.db"), 10, 1, "protein", false).unwrap();
         assert!(!index1.is_equivalent_to(&index3).unwrap());
+    }
+
+    /// Real N-terminal fragment of C. elegans CED-9 (UniProt P41958), from
+    /// tests/testdata/fasta/ced9.fasta.
+    const CED9_PREFIX: &str = "MTRCTADNSLTNPAYRRRTMATGEMKEFLGIKGTEPTDFGINSDAQDLPSPSRQASTRRM";
+
+    #[test]
+    fn test_frequency_bins_groups_counts_into_powers_of_two() {
+        // Bin b holds counts in [2^b, 2^(b+1)): 1 | 2-3 | 4-7 | 8-15 | ... | 256-511
+        let frequencies: HashMap<u64, usize> =
+            [(10, 1), (11, 1), (12, 1), (20, 2), (21, 3), (30, 4), (31, 7), (40, 8), (50, 300)]
+                .into_iter()
+                .collect();
+
+        let bins = ProteomeIndex::frequency_bins(&frequencies);
+
+        let expected: BTreeMap<u32, usize> =
+            [(0, 3), (1, 2), (2, 2), (3, 1), (8, 1)].into_iter().collect();
+        assert_eq!(bins, expected);
+    }
+
+    #[test]
+    fn test_n_smallest_by_key_selects_most_and_least_common() {
+        let frequencies: HashMap<u64, usize> =
+            [(100, 5), (200, 9), (300, 1), (400, 9), (500, 3)].into_iter().collect();
+
+        // Most common: highest count first, ties broken by ascending hash (200 before 400).
+        let most = ProteomeIndex::n_smallest_by_key(&frequencies, 3, |hash, count| {
+            (std::cmp::Reverse(count), hash)
+        });
+        assert_eq!(most, vec![(200, 9), (400, 9), (100, 5)]);
+
+        // Least common: lowest count first.
+        let least = ProteomeIndex::n_smallest_by_key(&frequencies, 3, |hash, count| (count, hash));
+        assert_eq!(least, vec![(300, 1), (500, 3), (100, 5)]);
+    }
+
+    #[test]
+    fn test_n_smallest_by_key_returns_all_when_n_exceeds_len() {
+        let frequencies: HashMap<u64, usize> = [(100, 2), (200, 1)].into_iter().collect();
+
+        let least = ProteomeIndex::n_smallest_by_key(&frequencies, 10, |hash, count| (count, hash));
+
+        assert_eq!(least, vec![(200, 1), (100, 2)]);
+    }
+
+    #[test]
+    fn test_resolve_kmer_string_recovers_kmer_text_from_hash() {
+        let temp_dir = tempdir().unwrap();
+        let index =
+            ProteomeIndex::new(temp_dir.path().join("ced9.db"), 10, 1, "protein", true).unwrap();
+        let sig = index.create_protein_signature(CED9_PREFIX, "ced9").unwrap();
+        let md5 = sig.signature().md5sum.clone();
+        index.store_signatures(vec![sig]).unwrap();
+
+        // The k-mer starting at position 0 is the first 10 residues of CED-9.
+        let stored = index.signatures.get(&md5).unwrap();
+        let (&hash, _) =
+            stored.kmer_positions().iter().find(|(_, positions)| positions.contains(&0)).unwrap();
+        drop(stored);
+
+        let inverted_index: HashMap<u64, Vec<u32>> = [(hash, vec![0])].into_iter().collect();
+        let resolved = index.resolve_kmer_string(hash, &inverted_index, std::slice::from_ref(&md5));
+
+        assert_eq!(resolved, "MTRCTADNSL");
+    }
+
+    #[test]
+    fn test_resolve_kmer_string_reports_unknown_hash() {
+        let temp_dir = tempdir().unwrap();
+        let index =
+            ProteomeIndex::new(temp_dir.path().join("ced9.db"), 10, 1, "protein", true).unwrap();
+
+        let resolved = index.resolve_kmer_string(42, &HashMap::new(), &[]);
+
+        assert_eq!(resolved, "<sequence unavailable, hash 42>");
+    }
+
+    #[test]
+    fn test_has_stored_sequences_follows_store_raw_sequences() {
+        let temp_dir = tempdir().unwrap();
+        for (store_raw, expected) in [(true, true), (false, false)] {
+            let path = temp_dir.path().join(format!("ced9-{store_raw}.db"));
+            let index = ProteomeIndex::new(path, 10, 1, "protein", store_raw).unwrap();
+            let sig = index.create_protein_signature(CED9_PREFIX, "ced9").unwrap();
+            index.store_signatures(vec![sig]).unwrap();
+
+            assert_eq!(index.has_stored_sequences(), expected, "store_raw={store_raw}");
+        }
     }
 
     #[test]

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -573,7 +573,7 @@ impl ProteomeIndex {
     /// Print one labelled list of example k-mers, noting how many share the boundary frequency.
     ///
     /// WHY the tie note: when hundreds of thousands of k-mers all occur once, listing ten of
-    /// them looks like a ranking but is really an arbitrary sample. Saying how many tie makes
+    /// them looks like a ranking but is an arbitrary sample. Saying how many tie makes
     /// that explicit.
     fn print_kmer_examples(
         &self,

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -432,11 +432,24 @@ impl ProteomeIndex {
         }
 
         let file = File::create(path)?;
-        let sink: Box<dyn Write> = if path.extension().is_some_and(|e| e == "gz") {
+        let mut sink: Box<dyn Write> = if path.extension().is_some_and(|e| e == "gz") {
             Box::new(GzEncoder::new(file, Compression::default()))
         } else {
             Box::new(file)
         };
+
+        // Totals go in a leading `#` comment rather than a column, because they are constant
+        // for the whole file and would otherwise be repeated on every row. Readers skip it
+        // with a comment prefix, e.g. polars' `read_csv(..., comment_prefix="#")`.
+        let total: usize = kmer_frequencies.values().sum();
+        writeln!(
+            sink,
+            "# total_kmers={total} unique_kmers={} moltype={} ksize={}",
+            kmer_frequencies.len(),
+            self.moltype,
+            self.ksize,
+        )?;
+
         let mut writer = csv::Writer::from_writer(sink);
         writer.write_record(["moltype", "ksize", "occurrences", "n_kmers"])?;
         let ksize = self.ksize.to_string();
@@ -480,7 +493,15 @@ impl ProteomeIndex {
         let (&first, &last) = (bins.keys().next().unwrap(), bins.keys().next_back().unwrap());
         let max_count = *bins.values().max().unwrap();
 
-        eprintln!("[save] K-mer frequency histogram ({} unique k-mers):", kmer_frequencies.len());
+        // Each k-mer is counted once per sequence containing it, so this is the total number
+        // of (sequence, k-mer) pairs the index holds rather than a count of k-mer positions.
+        let total: usize = kmer_frequencies.values().sum();
+        let unique = kmer_frequencies.len();
+        eprintln!(
+            "[save] K-mer frequency histogram: {total} total k-mers found, {unique} unique \
+             (mean {:.2} sequences per k-mer)",
+            total as f64 / unique as f64,
+        );
         for bin in first..=last {
             let count = bins.get(&bin).copied().unwrap_or(0);
             let (lo, hi) = (1u64 << bin, (1u64 << (bin + 1)) - 1);
@@ -1699,6 +1720,7 @@ mod tests {
     };
     use crate::tests::test_utils::{self, print_kmer_positions};
     use std::collections::{BTreeMap, HashMap};
+    use std::fs::File;
     use std::path::PathBuf;
 
     /// Keeping the tests for ProteomeIndex in a separate file because they're more like integration tests
@@ -2855,6 +2877,33 @@ mod tests {
     /// Real N-terminal fragment of C. elegans CED-9 (UniProt P41958), from
     /// tests/testdata/fasta/ced9.fasta.
     const CED9_PREFIX: &str = "MTRCTADNSLTNPAYRRRTMATGEMKEFLGIKGTEPTDFGINSDAQDLPSPSRQASTRRM";
+
+    #[test]
+    fn test_kmer_spectrum_csv_has_totals_comment_and_rows() {
+        use std::io::Read;
+
+        let temp_dir = tempdir().unwrap();
+        let index =
+            ProteomeIndex::new(temp_dir.path().join("spec.db"), 10, 1, "protein", true).unwrap();
+        // 3 k-mers seen once, 1 seen twice, 1 seen three times: 5 unique, 8 total.
+        let frequencies: HashMap<u64, usize> =
+            [(10, 1), (11, 1), (12, 1), (20, 2), (30, 3)].into_iter().collect();
+
+        let csv_path = temp_dir.path().join("spectrum.csv");
+        index.write_kmer_frequency_spectrum(&csv_path, &frequencies).unwrap();
+
+        let mut contents = String::new();
+        File::open(&csv_path).unwrap().read_to_string(&mut contents).unwrap();
+
+        assert_eq!(
+            contents,
+            "# total_kmers=8 unique_kmers=5 moltype=protein ksize=10\n\
+             moltype,ksize,occurrences,n_kmers\n\
+             protein,10,1,3\n\
+             protein,10,2,1\n\
+             protein,10,3,1\n"
+        );
+    }
 
     #[test]
     fn test_frequency_bins_groups_counts_into_powers_of_two() {

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -330,6 +330,8 @@ impl ProteomeIndex {
             inverted_index.len(),
         );
 
+        Self::log_kmer_frequency_stats(&kmer_frequencies);
+
         // Serialize and store the search cache
         eprintln!(
             "[save] Serializing SearchCache ({} targets, {} unique kmers)...",
@@ -349,6 +351,47 @@ impl ProteomeIndex {
         eprintln!("[save] search_cache written in {:.1}s", t2.elapsed().as_secs_f32());
 
         Ok(())
+    }
+
+    /// Log a k-mer frequency histogram and the top/bottom 10 k-mers by frequency to stderr.
+    ///
+    /// Bins are power-of-two ranges (1, 2-3, 4-7, ...) since k-mer frequency distributions
+    /// are typically heavily right-skewed (most k-mers occur once, a few occur very often).
+    fn log_kmer_frequency_stats(kmer_frequencies: &HashMap<u64, usize>) {
+        if kmer_frequencies.is_empty() {
+            return;
+        }
+
+        let mut bins: BTreeMap<u32, usize> = BTreeMap::new();
+        for &freq in kmer_frequencies.values() {
+            let bin = usize::BITS - freq.leading_zeros() - 1;
+            *bins.entry(bin).or_insert(0) += 1;
+        }
+
+        eprintln!("[save] K-mer frequency histogram ({} unique k-mers):", kmer_frequencies.len());
+        let max_count = *bins.values().max().unwrap();
+        const BAR_WIDTH: usize = 40;
+        for (bin, count) in &bins {
+            let lo = 1u64 << bin;
+            let hi = (1u64 << (bin + 1)) - 1;
+            let label = if lo == hi { format!("{lo}") } else { format!("{lo}-{hi}") };
+            let bar_len = (count * BAR_WIDTH) / max_count;
+            let bar = "#".repeat(bar_len.max(1));
+            eprintln!("[save]   {label:>12} occurrences: {count:>10} k-mers  {bar}");
+        }
+
+        let mut by_frequency: Vec<(&u64, &usize)> = kmer_frequencies.iter().collect();
+        by_frequency.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+
+        eprintln!("[save] Top 10 most common k-mers (hash: occurrences):");
+        for (hash, count) in by_frequency.iter().take(10) {
+            eprintln!("[save]   {hash}: {count}");
+        }
+
+        eprintln!("[save] Bottom 10 least common k-mers (hash: occurrences):");
+        for (hash, count) in by_frequency.iter().rev().take(10) {
+            eprintln!("[save]   {hash}: {count}");
+        }
     }
 
     /// Save the current index state to RocksDB using chunked storage format

--- a/src/rust/main.rs
+++ b/src/rust/main.rs
@@ -39,6 +39,12 @@ enum Commands {
         /// Progress notification interval (number of sequences between progress reports)
         #[arg(short, long, default_value = "10000")]
         progress_interval: u32,
+
+        /// Write the k-mer frequency spectrum to this CSV path for plotting across alphabets
+        /// and k-sizes. Gzip-compressed when the path ends in .gz. Columns:
+        /// moltype, ksize, occurrences, n_kmers.
+        #[arg(long, value_name = "PATH")]
+        kmer_stats_out: Option<PathBuf>,
     },
     /// Search query sequences against a protein database
     Search {
@@ -148,7 +154,15 @@ fn main() -> IndexResult<()> {
     eprintln!("kmerseek {}", env!("CARGO_PKG_VERSION"));
 
     match cli.command {
-        Commands::Index { input, output, ksize, encoding, shuffled_seed, progress_interval } => {
+        Commands::Index {
+            input,
+            output,
+            ksize,
+            encoding,
+            shuffled_seed,
+            progress_interval,
+            kmer_stats_out,
+        } => {
             eprintln!("Indexing FASTA file: {}", input.display());
 
             // Scaled factor is always 1 (captures all k-mers)
@@ -218,7 +232,7 @@ fn main() -> IndexResult<()> {
             index.enable_compactions()?;
 
             // Save the index state for loading
-            index.save_state()?;
+            index.save_state_with_kmer_stats(kmer_stats_out.as_deref())?;
 
             eprintln!("Indexing completed successfully!");
             eprintln!("Database saved to: {}", output_path.display());

--- a/src/rust/sketch.rs
+++ b/src/rust/sketch.rs
@@ -392,17 +392,18 @@ impl ProteinSketch {
             let moltype_str = self.moltype.to_string();
             if moltype_str != "protein" {
                 let encoded_sequence = if let Some(ref alpha) = custom_hp {
-                    // Custom HP alphabets: apply the HP table directly, uppercased to match
-                    // the hashes stored in minhash (sourmash uppercases before hashing).
+                    // Custom HP alphabets: apply the HP table directly, keeping the table's
+                    // lowercase h/p so output matches built-in hp/dayhoff (which sourmash
+                    // encodes lowercase). Unmapped residues (X/U/O) stay uppercase, also
+                    // matching sourmash. This string is display-only — matched regions and
+                    // k-mer stats — so its case is independent of hashing, which must
+                    // uppercase because sourmash uppercases protein input before hashing.
                     let table = alpha.table();
                     sequence
                         .bytes()
                         .map(|b| {
-                            table
-                                .get(&b.to_ascii_uppercase())
-                                .copied()
-                                .unwrap_or(b)
-                                .to_ascii_uppercase() as char
+                            let upper = b.to_ascii_uppercase();
+                            table.get(&upper).copied().unwrap_or(upper) as char
                         })
                         .collect::<String>()
                 } else {

--- a/src/rust/tests/test_hp_encoding.rs
+++ b/src/rust/tests/test_hp_encoding.rs
@@ -47,8 +47,9 @@ mod tests {
         }
     }
 
-    /// The encoded_sequence for a custom HP alphabet must consist solely of 'H' and 'P'
-    /// characters (or pass-through bytes for unknown amino acids).
+    /// The encoded_sequence for a custom HP alphabet must consist solely of 'h' and 'p'
+    /// characters (or pass-through bytes for unknown amino acids). Lowercase matches the
+    /// built-in hp/dayhoff encodings, which sourmash emits lowercase.
     #[test]
     fn test_custom_hp_encoded_sequence_contains_hp_chars() {
         let seq = "MKTAYIAKQRFLVS";
@@ -64,8 +65,8 @@ mod tests {
 
         for ch in enc.chars() {
             assert!(
-                ch == 'H' || ch == 'P',
-                "encoded_sequence char {ch:?} is not 'H' or 'P' — raw amino acid stored instead (Bug 2)"
+                ch == 'h' || ch == 'p',
+                "encoded_sequence char {ch:?} is not 'h' or 'p' — raw amino acid stored instead (Bug 2)"
             );
         }
     }
@@ -170,8 +171,8 @@ mod tests {
                 .unwrap_or_else(|| panic!("{moltype}: encoded_sequence is None (Bug 2)"));
             for ch in enc.chars() {
                 assert!(
-                    ch == 'H' || ch == 'P',
-                    "{moltype}: encoded_sequence char {ch:?} is not H/P (Bug 2 regression)"
+                    ch == 'h' || ch == 'p',
+                    "{moltype}: encoded_sequence char {ch:?} is not h/p (Bug 2 regression)"
                 );
             }
         }


### PR DESCRIPTION
## Summary
During indexing, log the k-mer frequency distribution to stderr so the shape of an index is visible without a separate analysis pass, and optionally save it as CSV for plotting.

- A power-of-two-binned histogram of k-mer occurrence counts, with the total and unique k-mer counts, the mean, and the median.
- The 10 most and 10 least common k-mers, shown as encoded k-mer strings rather than hashes. Hashes are one-way murmur values, so each is resolved back to its text by looking up a signature containing it and slicing the stored sequence at the recorded position.
- `--kmer-stats-out PATH` writes the frequency spectrum as CSV, gzipped when the path ends in `.gz`.

Each k-mer is counted once per sequence containing it, so "total" is the number of (sequence, k-mer) pairs rather than a count of k-mer positions.

## Example output

```
[save] K-mer frequency histogram: 164269039 total k-mers found, 16711823 unique (mean 9.83, median 8.0 sequences per k-mer)
[save]              1 occurrences:     490084 k-mers  #
[save]            2-3 occurrences:    1119750 k-mers  ##
[save]            4-7 occurrences:    4181835 k-mers  ##########
[save]           8-15 occurrences:   15943791 k-mers  ########################################
...
[save] 10 most common k-mers (encoded k-mer: occurrences):
[save]   hhhhhhhhhhphphhhhphhpphh: 1534
[save]   hhhhhhhphphhhhphhpphhphh: 1501
...
[save] 10 least common k-mers (encoded k-mer: occurrences):
[save]   hphpphXhph: 1
[save]   (2485879 k-mers occur 1x; showing an arbitrary sample)
```

The CSV carries the totals in a leading `#` comment rather than a column, since they are constant for the file and would otherwise repeat on every row. Readers skip it with a comment prefix, for example `pl.read_csv(f, comment_prefix="#")`.

```
# total_kmers=164269039 unique_kmers=16711823 mean_seqs_per_kmer=9.8295 median_seqs_per_kmer=8.0 moltype=hp ksize=24
moltype,ksize,occurrences,n_kmers
hp,24,1,490084
hp,24,2,712205
```

`moltype` and `ksize` repeat per row so files from different runs concatenate into one frame.

## SwissProt sweep

134 indexes over all 572,970 SwissProt sequences (207.6 M residues): protein k=5-15, dayhoff k=10-20, and seven HP alphabets at k=15-30. Each index was deleted after its spectrum was written. `hp_lehninger` was skipped because it produces hashes identical to `hp`.

Spectra are in `~/data/kmerseek-kmer-spectra/` (134 files, 1.1 MB total).

### What the sweep shows

HP alphabets saturate their k-mer space through k=24. Every possible two-letter k-mer appears from k=15 to k=24, so a shared k-mer carries almost no information at those sizes:

| k | 2^k possible | observed unique | ratio | median seqs/k-mer |
|---|---|---|---|---|
| 15 | 32,768 | 72,543 | 2.21 | 2.0 |
| 18 | 262,144 | 310,440 | 1.18 | 543.0 |
| 21 | 2,097,152 | 2,151,722 | 1.03 | 68.0 |
| 24 | 16,777,216 | 16,711,823 | 1.00 | 8.0 |

Observed unique exceeds 2^k below k=24 because k-mers containing `X`, `U` or `O` are not two-letter. At k=15, 39,775 of the 72,543 unique k-mers (54.8%) are outside the pure H/P space.

The median catches something the mean hides. At hp k=15 the mean is 2,275 but the median is 2, because more than half the unique k-mers are X-containing singletons. At k=16 the singleton fraction drops below half and the median jumps to 1,857. A median far below the mean at low k means the count is dominated by ambiguity artifacts rather than by real k-mers.

The shuffled negative control produces more unique k-mers than any real alphabet at k=30: 115,555,230 against 83.1 M-100.3 M. Real alphabets group biochemically similar residues, so real proteins repeat patterns under them; scrambling the partition breaks that and spreads sequences over more distinct k-mers. The control behaves as intended.

protein k=5 covers 98.1% of its 3,200,000-k-mer space with a median of 29 sequences per k-mer. From k=7 up the median is 1 and 67-83% of k-mers are singletons. dayhoff k=10 occupies 24.6% of its 6^10 space with a median of 3.

Total k-mers stays nearly constant across k within an alphabet (protein: 181.5 M at k=5 to 177.5 M at k=15), as expected when the count tracks residues.

### Full results

All 134 runs verified: the `# total_kmers=` header reconciles with `sum(occurrences x n_kmers)` over the rows in every file.

<details><summary><b>protein</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| protein | 5 | 181,506,140 | 3,140,710 | 57.79 | 29.0 | 3.1% |
| protein | 6 | 181,368,370 | 33,936,833 | 5.34 | 3.0 | 31.7% |
| protein | 7 | 181,033,441 | 88,955,845 | 2.04 | 1.0 | 66.7% |
| protein | 8 | 180,644,631 | 107,273,113 | 1.68 | 1.0 | 76.8% |
| protein | 9 | 180,225,768 | 112,504,399 | 1.60 | 1.0 | 78.9% |
| protein | 10 | 179,789,104 | 115,767,352 | 1.55 | 1.0 | 79.9% |
| protein | 11 | 179,343,169 | 118,428,118 | 1.51 | 1.0 | 80.6% |
| protein | 12 | 178,888,285 | 120,695,883 | 1.48 | 1.0 | 81.3% |
| protein | 13 | 178,429,587 | 122,660,599 | 1.45 | 1.0 | 81.9% |
| protein | 14 | 177,966,234 | 124,377,148 | 1.43 | 1.0 | 82.5% |
| protein | 15 | 177,500,498 | 125,883,747 | 1.41 | 1.0 | 82.9% |

</details>

<details><summary><b>dayhoff</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| dayhoff | 10 | 172,339,558 | 14,848,084 | 11.61 | 3.0 | 31.1% |
| dayhoff | 11 | 172,084,420 | 33,976,195 | 5.06 | 2.0 | 42.7% |
| dayhoff | 12 | 171,752,076 | 58,988,034 | 2.91 | 1.0 | 55.7% |
| dayhoff | 13 | 171,378,861 | 80,110,845 | 2.14 | 1.0 | 66.3% |
| dayhoff | 14 | 170,983,997 | 92,775,115 | 1.84 | 1.0 | 72.6% |
| dayhoff | 15 | 170,573,381 | 99,379,499 | 1.72 | 1.0 | 75.8% |
| dayhoff | 16 | 170,154,673 | 103,083,332 | 1.65 | 1.0 | 77.3% |
| dayhoff | 17 | 169,728,023 | 105,549,098 | 1.61 | 1.0 | 78.3% |
| dayhoff | 18 | 169,295,834 | 107,451,826 | 1.58 | 1.0 | 78.9% |
| dayhoff | 19 | 168,860,739 | 109,049,924 | 1.55 | 1.0 | 79.5% |
| dayhoff | 20 | 168,422,092 | 110,447,870 | 1.52 | 1.0 | 79.9% |

</details>

<details><summary><b>hp</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp | 15 | 165,059,303 | 72,543 | 2275.33 | 2.0 | 48.7% |
| hp | 16 | 165,939,087 | 108,613 | 1527.80 | 1857.0 | 36.3% |
| hp | 17 | 166,252,293 | 176,936 | 939.62 | 1035.0 | 24.1% |
| hp | 18 | 166,249,163 | 310,440 | 535.53 | 543.0 | 14.6% |
| hp | 19 | 166,067,392 | 574,795 | 288.92 | 276.0 | 8.3% |
| hp | 20 | 165,786,060 | 1,101,168 | 150.55 | 138.0 | 4.5% |
| hp | 21 | 165,445,747 | 2,151,722 | 76.89 | 68.0 | 2.4% |
| hp | 22 | 165,072,257 | 4,250,821 | 38.83 | 33.0 | 1.3% |
| hp | 23 | 164,677,628 | 8,445,937 | 19.50 | 16.0 | 0.7% |
| hp | 24 | 164,269,039 | 16,711,823 | 9.83 | 8.0 | 2.9% |
| hp | 25 | 163,852,353 | 31,205,635 | 5.25 | 4.0 | 14.8% |
| hp | 26 | 163,428,939 | 50,517,302 | 3.24 | 2.0 | 34.1% |
| hp | 27 | 163,002,744 | 69,420,759 | 2.35 | 1.0 | 51.5% |
| hp | 28 | 162,573,323 | 84,087,897 | 1.93 | 1.0 | 63.5% |
| hp | 29 | 162,141,589 | 94,001,873 | 1.72 | 1.0 | 70.9% |
| hp | 30 | 161,708,001 | 100,290,250 | 1.61 | 1.0 | 75.2% |

</details>

<details><summary><b>hp_thomas_dill</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp_thomas_dill | 15 | 161,962,395 | 72,533 | 2232.95 | 2.0 | 48.6% |
| hp_thomas_dill | 16 | 163,243,557 | 108,553 | 1503.81 | 952.0 | 36.2% |
| hp_thomas_dill | 17 | 163,844,921 | 176,813 | 926.66 | 663.0 | 24.0% |
| hp_thomas_dill | 18 | 164,044,115 | 310,278 | 528.70 | 389.0 | 14.5% |
| hp_thomas_dill | 19 | 164,006,170 | 574,616 | 285.42 | 209.0 | 8.3% |
| hp_thomas_dill | 20 | 163,830,758 | 1,100,966 | 148.81 | 106.0 | 4.5% |
| hp_thomas_dill | 21 | 163,571,555 | 2,151,513 | 76.03 | 52.0 | 2.4% |
| hp_thomas_dill | 22 | 163,256,290 | 4,247,152 | 38.44 | 25.0 | 1.6% |
| hp_thomas_dill | 23 | 162,911,504 | 8,328,616 | 19.56 | 12.0 | 3.9% |
| hp_thomas_dill | 24 | 162,542,972 | 15,592,399 | 10.42 | 6.0 | 11.3% |
| hp_thomas_dill | 25 | 162,157,826 | 26,769,582 | 6.06 | 3.0 | 22.2% |
| hp_thomas_dill | 26 | 161,761,611 | 41,288,634 | 3.92 | 2.0 | 34.6% |
| hp_thomas_dill | 27 | 161,359,557 | 57,002,869 | 2.83 | 2.0 | 46.9% |
| hp_thomas_dill | 28 | 160,949,010 | 71,266,327 | 2.26 | 1.0 | 57.4% |
| hp_thomas_dill | 29 | 160,534,347 | 82,486,111 | 1.95 | 1.0 | 65.3% |
| hp_thomas_dill | 30 | 160,117,034 | 90,517,554 | 1.77 | 1.0 | 70.7% |

</details>

<details><summary><b>hp_kyte_doolittle</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp_kyte_doolittle | 15 | 159,920,435 | 71,151 | 2247.62 | 2.0 | 46.3% |
| hp_kyte_doolittle | 16 | 161,766,474 | 107,624 | 1503.07 | 598.0 | 35.0% |
| hp_kyte_doolittle | 17 | 162,746,742 | 176,201 | 923.64 | 433.0 | 23.5% |
| hp_kyte_doolittle | 18 | 163,197,204 | 309,863 | 526.68 | 261.0 | 14.3% |
| hp_kyte_doolittle | 19 | 163,324,414 | 574,341 | 284.37 | 142.0 | 8.2% |
| hp_kyte_doolittle | 20 | 163,257,093 | 1,100,777 | 148.31 | 72.0 | 4.5% |
| hp_kyte_doolittle | 21 | 163,070,902 | 2,150,310 | 75.84 | 36.0 | 2.6% |
| hp_kyte_doolittle | 22 | 162,805,145 | 4,209,603 | 38.67 | 17.0 | 3.5% |
| hp_kyte_doolittle | 23 | 162,492,877 | 7,986,666 | 20.35 | 9.0 | 8.8% |
| hp_kyte_doolittle | 24 | 162,150,624 | 14,172,950 | 11.44 | 5.0 | 17.2% |
| hp_kyte_doolittle | 25 | 161,784,410 | 23,143,497 | 6.99 | 3.0 | 26.5% |
| hp_kyte_doolittle | 26 | 161,402,750 | 34,691,411 | 4.65 | 2.0 | 36.0% |
| hp_kyte_doolittle | 27 | 161,012,159 | 47,869,100 | 3.36 | 2.0 | 45.1% |
| hp_kyte_doolittle | 28 | 160,611,182 | 61,198,019 | 2.62 | 1.0 | 53.5% |
| hp_kyte_doolittle | 29 | 160,203,595 | 73,238,309 | 2.19 | 1.0 | 60.8% |
| hp_kyte_doolittle | 30 | 159,792,220 | 83,119,736 | 1.92 | 1.0 | 66.6% |

</details>

<details><summary><b>hp_thomas_dill_no_c</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp_thomas_dill_no_c | 15 | 161,043,965 | 72,132 | 2232.63 | 2.0 | 48.0% |
| hp_thomas_dill_no_c | 16 | 162,512,261 | 108,269 | 1501.00 | 795.0 | 35.8% |
| hp_thomas_dill_no_c | 17 | 163,247,997 | 176,619 | 924.29 | 569.0 | 23.9% |
| hp_thomas_dill_no_c | 18 | 163,539,228 | 310,154 | 527.28 | 340.0 | 14.5% |
| hp_thomas_dill_no_c | 19 | 163,563,131 | 574,551 | 284.68 | 183.0 | 8.2% |
| hp_thomas_dill_no_c | 20 | 163,428,975 | 1,100,945 | 148.44 | 94.0 | 4.5% |
| hp_thomas_dill_no_c | 21 | 163,196,360 | 2,151,456 | 75.85 | 46.0 | 2.4% |
| hp_thomas_dill_no_c | 22 | 162,900,432 | 4,241,765 | 38.40 | 22.0 | 1.9% |
| hp_thomas_dill_no_c | 23 | 162,569,269 | 8,245,460 | 19.72 | 11.0 | 5.5% |
| hp_thomas_dill_no_c | 24 | 162,211,387 | 15,149,659 | 10.71 | 6.0 | 13.6% |
| hp_thomas_dill_no_c | 25 | 161,833,840 | 25,509,795 | 6.34 | 3.0 | 23.9% |
| hp_thomas_dill_no_c | 26 | 161,442,562 | 38,928,296 | 4.15 | 2.0 | 35.0% |
| hp_thomas_dill_no_c | 27 | 161,044,489 | 53,775,993 | 2.99 | 2.0 | 46.1% |
| hp_thomas_dill_no_c | 28 | 160,637,608 | 67,797,198 | 2.37 | 1.0 | 56.0% |
| hp_thomas_dill_no_c | 29 | 160,225,643 | 79,345,828 | 2.02 | 1.0 | 63.7% |
| hp_thomas_dill_no_c | 30 | 159,811,079 | 87,968,055 | 1.82 | 1.0 | 69.4% |

</details>

<details><summary><b>hp_lehninger_plus_c</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp_lehninger_plus_c | 15 | 164,949,486 | 72,517 | 2274.63 | 2.0 | 48.6% |
| hp_lehninger_plus_c | 16 | 165,900,244 | 108,575 | 1527.98 | 1647.0 | 36.2% |
| hp_lehninger_plus_c | 17 | 166,263,736 | 176,901 | 939.87 | 959.0 | 24.1% |
| hp_lehninger_plus_c | 18 | 166,298,109 | 310,414 | 535.73 | 514.0 | 14.6% |
| hp_lehninger_plus_c | 19 | 166,142,286 | 574,778 | 289.05 | 264.0 | 8.3% |
| hp_lehninger_plus_c | 20 | 165,878,404 | 1,101,143 | 150.64 | 133.0 | 4.5% |
| hp_lehninger_plus_c | 21 | 165,549,829 | 2,151,697 | 76.94 | 66.0 | 2.4% |
| hp_lehninger_plus_c | 22 | 165,182,713 | 4,250,796 | 38.86 | 32.0 | 1.3% |
| hp_lehninger_plus_c | 23 | 164,792,429 | 8,444,462 | 19.51 | 15.0 | 0.8% |
| hp_lehninger_plus_c | 24 | 164,386,505 | 16,650,367 | 9.87 | 7.0 | 3.8% |
| hp_lehninger_plus_c | 25 | 163,971,137 | 30,771,661 | 5.33 | 4.0 | 16.2% |
| hp_lehninger_plus_c | 26 | 163,548,450 | 49,436,748 | 3.31 | 2.0 | 34.6% |
| hp_lehninger_plus_c | 27 | 163,122,597 | 67,931,929 | 2.40 | 1.0 | 51.3% |
| hp_lehninger_plus_c | 28 | 162,692,568 | 82,596,630 | 1.97 | 1.0 | 63.1% |
| hp_lehninger_plus_c | 29 | 162,260,870 | 92,732,034 | 1.75 | 1.0 | 70.5% |
| hp_lehninger_plus_c | 30 | 161,826,899 | 99,287,384 | 1.63 | 1.0 | 74.9% |

</details>

<details><summary><b>hp_pbotc_1st_ed</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp_pbotc_1st_ed | 15 | 163,853,420 | 72,993 | 2244.78 | 2.0 | 49.3% |
| hp_pbotc_1st_ed | 16 | 164,708,477 | 108,876 | 1512.81 | 1718.0 | 36.6% |
| hp_pbotc_1st_ed | 17 | 165,009,184 | 177,076 | 931.86 | 1002.0 | 24.2% |
| hp_pbotc_1st_ed | 18 | 165,001,392 | 310,492 | 531.42 | 534.0 | 14.7% |
| hp_pbotc_1st_ed | 19 | 164,818,686 | 574,807 | 286.74 | 274.0 | 8.3% |
| hp_pbotc_1st_ed | 20 | 164,541,888 | 1,101,142 | 149.43 | 137.0 | 4.5% |
| hp_pbotc_1st_ed | 21 | 164,208,724 | 2,151,679 | 76.32 | 68.0 | 2.4% |
| hp_pbotc_1st_ed | 22 | 163,843,409 | 4,250,759 | 38.54 | 33.0 | 1.3% |
| hp_pbotc_1st_ed | 23 | 163,460,066 | 8,442,789 | 19.36 | 16.0 | 0.9% |
| hp_pbotc_1st_ed | 24 | 163,062,505 | 16,608,700 | 9.82 | 7.0 | 4.1% |
| hp_pbotc_1st_ed | 25 | 162,656,368 | 30,524,353 | 5.33 | 4.0 | 16.3% |
| hp_pbotc_1st_ed | 26 | 162,242,784 | 48,804,225 | 3.32 | 2.0 | 34.2% |
| hp_pbotc_1st_ed | 27 | 161,825,488 | 66,888,777 | 2.42 | 1.0 | 50.6% |
| hp_pbotc_1st_ed | 28 | 161,404,833 | 81,201,599 | 1.99 | 1.0 | 62.3% |
| hp_pbotc_1st_ed | 29 | 160,981,346 | 91,029,438 | 1.77 | 1.0 | 69.8% |
| hp_pbotc_1st_ed | 30 | 160,556,477 | 97,327,836 | 1.65 | 1.0 | 74.2% |

</details>

<details><summary><b>hp_shuffled_control</b></summary>

| moltype | k | total k-mers | unique | mean seqs/k-mer | median seqs/k-mer | singletons |
|---|---|---|---|---|---|---|
| hp_shuffled_control | 15 | 171,026,680 | 73,888 | 2314.67 | 1.0 | 50.3% |
| hp_shuffled_control | 16 | 171,633,899 | 109,765 | 1563.65 | 2215.0 | 37.3% |
| hp_shuffled_control | 17 | 171,742,468 | 177,955 | 965.09 | 1153.0 | 24.7% |
| hp_shuffled_control | 18 | 171,587,164 | 311,388 | 551.04 | 589.0 | 15.0% |
| hp_shuffled_control | 19 | 171,291,308 | 575,716 | 297.53 | 298.0 | 8.5% |
| hp_shuffled_control | 20 | 170,923,747 | 1,102,102 | 155.09 | 149.0 | 4.6% |
| hp_shuffled_control | 21 | 170,520,141 | 2,152,676 | 79.21 | 74.0 | 2.5% |
| hp_shuffled_control | 22 | 170,093,006 | 4,251,832 | 40.00 | 37.0 | 1.3% |
| hp_shuffled_control | 23 | 169,655,782 | 8,448,034 | 20.08 | 18.0 | 0.7% |
| hp_shuffled_control | 24 | 169,212,585 | 16,812,442 | 10.06 | 9.0 | 1.2% |
| hp_shuffled_control | 25 | 168,764,979 | 32,418,805 | 5.21 | 4.0 | 10.0% |
| hp_shuffled_control | 26 | 168,313,418 | 55,059,702 | 3.06 | 2.0 | 30.4% |
| hp_shuffled_control | 27 | 167,860,022 | 78,353,227 | 2.14 | 1.0 | 50.9% |
| hp_shuffled_control | 28 | 167,406,738 | 96,520,424 | 1.73 | 1.0 | 65.3% |
| hp_shuffled_control | 29 | 166,950,890 | 108,432,949 | 1.54 | 1.0 | 74.0% |
| hp_shuffled_control | 30 | 166,496,217 | 115,555,230 | 1.44 | 1.0 | 78.9% |

</details>

## Notes on output design
- Empty histogram bins print with a zero count rather than being skipped, so gaps in the distribution are visible.
- When many k-mers tie at the boundary frequency, a trailing note says how many, since listing ten of them otherwise looks like a ranking.
- With `store_raw_sequences=false` there is no text to slice, so the k-mer lists are skipped with one line instead of printing 20 `<sequence unavailable>` rows.
- Top and bottom selection uses a bounded heap rather than sorting. Sorting every unique k-mer to read off 10 entries would allocate and sort a Vec the size of the whole index, which is over 125 M entries at protein k=15.

## Test plan
- [x] `cargo test --no-default-features --lib -- --test-threads=1` — 136/136 pass
- [x] `cargo fmt --check` and `cargo clippy` clean
- [x] 134-run SwissProt sweep completed with no failures
- [x] In all 134 spectra, the `# total_kmers=` header reconciles with `sum(occurrences x n_kmers)` over the rows
- [x] Tests use exact-value assertions, covering binning, the exact median including the even-count midpoint, top/bottom selection with tie-breaking, k-mer text resolution against a real CED-9 fragment, and the full CSV byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)