### PR TITLE
Add --remove-low-complexity to drop homopolymer k-mers at index time

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,28 @@ Removed 75 of 9063 k-mer windows as low-complexity (0.83%)
 ```
 
 The setting is **stored in the index**, and `kmerseek search` reads it back and
-builds query sketches the same way -- you don't repeat the flag when searching:
+builds query sketches the same way. You don't repeat the flag when searching, and
+search says plainly what the index holds and what it is doing:
 
 ```
-Remove low-complexity k-mers: true (from index)
+Index: low-complexity k-mers were REMOVED when it was built
+This search: low-complexity k-mers are REMOVED from query sketches (matching the index)
 ```
+
+Pass `--remove-low-complexity` (or `--remove-low-complexity false`) to `search`
+only to override that deliberately. Disagreeing with the index is allowed but
+warned about:
+
+```
+This search: low-complexity k-mers are REMOVED from query sketches (--remove-low-complexity)
+WARNING: this disagrees with the index. Containment is intersection / query_size,
+so k-mers present on only one side still count toward the denominator and skew scores.
+```
+
+Results carry the setting too, in a `remove_low_complexity` column next to
+`ksize`/`scaled`/`moltype`, so a CSV is self-describing without the command line
+that produced it. It is a column rather than a `#` comment line because a comment
+would break `pl.scan_csv` and every other plain CSV reader.
 
 That symmetry matters. Containment is `intersection / query_size`, so if the index
 dropped these k-mers but queries kept them, they'd match nothing while still

--- a/README.md
+++ b/README.md
@@ -34,6 +34,52 @@ Run real-world examples like:
 cargo run --example test_bcl2_processing
 ```
 
+## Removing low-complexity k-mers
+
+Low-complexity k-mers -- homopolymer runs like a poly-glutamate tract (`EEEEE`) or,
+under a reduced alphabet, an all-hydrophobic window (`hhhhh`) -- are abundant and
+carry little discriminative signal. Pass `--remove-low-complexity` at index time to
+drop them:
+
+```bash
+kmerseek index -i proteome.fasta --ksize 10 --encoding hp --remove-low-complexity
+```
+
+Two independent checks run per k-mer: the **raw amino-acid** window (any encoding),
+and for `hp`-family encodings the **HP-encoded** window as well. The second catches
+windows that aren't raw homopolymers but still collapse to one symbol -- `LIVMA` is
+five different residues that all encode to `h`.
+
+Indexing reports what was removed, so you can tell whether the flag mattered:
+
+```
+Removed 75 of 9063 k-mer windows as low-complexity (0.83%)
+```
+
+The setting is **stored in the index**, and `kmerseek search` reads it back and
+builds query sketches the same way -- you don't repeat the flag when searching:
+
+```
+Remove low-complexity k-mers: true (from index)
+```
+
+That symmetry matters. Containment is `intersection / query_size`, so if the index
+dropped these k-mers but queries kept them, they'd match nothing while still
+inflating the denominator -- deflating scores for exactly the queries containing
+low-complexity regions.
+
+Auto-generated filenames gain a `.nolowcomplexity` segment, so builds with and
+without removal coexist instead of overwriting each other:
+
+```
+proteome.fasta.hp.k10.scaled1.kmerseek.rocksdb                  # default
+proteome.fasta.hp.k10.scaled1.nolowcomplexity.kmerseek.rocksdb  # --remove-low-complexity
+```
+
+Removal is **off by default**; existing indexes and workflows are unaffected.
+Note that only *exact* homopolymers are dropped -- a near-homopolymer such as
+`hhhhhhhhhp` is kept.
+
 ## Visualizing hits
 
 `scripts/visualize_hits.py` renders a per-gene PNG+SVG pair showing every hit
@@ -143,6 +189,15 @@ let index = ProteomeIndex::builder()
     .scaled(1)
     .moltype("protein")
     .store_raw_sequences(true)
+    .build()?;
+
+// Dropping low-complexity (homopolymer) k-mers
+let index = ProteomeIndex::builder()
+    .path("/path/to/database.db")
+    .ksize(5)
+    .scaled(1)
+    .moltype("hp")
+    .remove_low_complexity(true)
     .build()?;
 ```
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -222,28 +222,21 @@ fn benchmark_encodings_encode_kmer_with_encoding_fn(c: &mut Criterion) {
 fn benchmark_process_protein_kmers(c: &mut Criterion) {
     for moltype in MOLTYPES {
         for ksize in KSIZES {
-            let (index, _) = setup_test_index(ksize, moltype);
-
-            // Create a test protein signature
-            let mut protein_sig = kmerseek::sketch::ProteinSketch::new(
-                "test_protein",
-                ksize,
-                1, // scaled
-                moltype,
-            )
-            .unwrap();
-
-            // Add the protein sequence
-            protein_sig.add_protein(TEST_PROTEIN, true).unwrap();
-
             c.bench_function(&format!("process_protein_kmers_{}_{}", moltype, ksize), |b| {
                 b.iter(|| {
                     // Record start time for CPU measurement
                     let start_time = Instant::now();
 
-                    // Process kmers
-                    let mut sig = protein_sig.clone();
-                    index.process_kmers(TEST_PROTEIN, &mut sig).unwrap();
+                    // A fresh sketch each iteration: add_protein both sketches the
+                    // sequence and maps k-mer positions, which is the work measured.
+                    let mut sig = kmerseek::sketch::ProteinSketch::new(
+                        "test_protein",
+                        ksize,
+                        1, // scaled
+                        moltype,
+                    )
+                    .unwrap();
+                    sig.add_protein(TEST_PROTEIN, true).unwrap();
 
                     // Record end time
                     let end_time = Instant::now();
@@ -408,7 +401,7 @@ FSAEFLKVFIPSLFLSHVLALGLGIYIGKRLSTPSASTY";
 ///
 /// Also benchmarks batch sizes to help tune the --batch-size CLI default.
 fn benchmark_search_throughput(c: &mut Criterion) {
-    use kmerseek::search::ProteinSearcher;
+    use kmerseek::search::{ProteinSearcher, SearchFilters};
     use kmerseek::sketch::ProteinSketch;
 
     let target_fasta =
@@ -452,7 +445,9 @@ fn benchmark_search_throughput(c: &mut Criterion) {
             // benchmark: single query search_one()
             {
                 let bench_name = format!("search_one_{moltype}_k{ksize}");
-                c.bench_function(&bench_name, |b| b.iter(|| searcher.search_one(&query_sig)));
+                c.bench_function(&bench_name, |b| {
+                    b.iter(|| searcher.search_one(&query_sig, &SearchFilters::default()))
+                });
             }
 
             // benchmark: batch search at several batch sizes (simulated by repeating query)
@@ -460,7 +455,12 @@ fn benchmark_search_throughput(c: &mut Criterion) {
                 let queries: Vec<ProteinSketch> = vec![query_sig.clone(); n_queries];
                 let bench_name = format!("search_batch{n_queries}_{moltype}_k{ksize}");
                 c.bench_function(&bench_name, |b| {
-                    b.iter(|| queries.iter().map(|q| searcher.search_one(q)).collect::<Vec<_>>())
+                    b.iter(|| {
+                        queries
+                            .iter()
+                            .map(|q| searcher.search_one(q, &SearchFilters::default()))
+                            .collect::<Vec<_>>()
+                    })
                 });
             }
         }
@@ -470,7 +470,7 @@ fn benchmark_search_throughput(c: &mut Criterion) {
 /// Benchmark indexing and searching the 2.8k uncharacterized protein file with hp encoding
 /// at large k-mer sizes (15, 20, 30) to see index build time, load time, and search selectivity.
 fn benchmark_index_hp_large_k(c: &mut Criterion) {
-    use kmerseek::search::ProteinSearcher;
+    use kmerseek::search::{ProteinSearcher, SearchFilters};
     use kmerseek::sketch::ProteinSketch;
 
     let target_fasta =
@@ -526,7 +526,9 @@ fn benchmark_index_hp_large_k(c: &mut Criterion) {
             let mut query_sig = ProteinSketch::new(&query_seq.0, ksize, 1, "hp").unwrap();
             query_sig.add_protein(&query_seq.1, true).unwrap();
             let search_name = format!("search_one_hp_k{ksize}");
-            group.bench_function(&search_name, |b| b.iter(|| searcher.search_one(&query_sig)));
+            group.bench_function(&search_name, |b| {
+                b.iter(|| searcher.search_one(&query_sig, &SearchFilters::default()))
+            });
         }
     }
     group.finish();

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -12,7 +12,6 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use rocksdb::{Options, DB};
 use serde::{Deserialize, Serialize};
-use sourmash::_hash_murmur;
 use sourmash::collection::Collection;
 use sourmash::manifest::Manifest;
 use sourmash::signature::SigsTrait;
@@ -20,11 +19,8 @@ use sourmash::sketch::minhash::KmerMinHash;
 use sourmash::storage::{FSStorage, InnerStorage};
 
 use crate::aminoacid::AminoAcidAmbiguity;
-use crate::encoding::{
-    encode_with_fn, get_encoding_fn_from_moltype, get_hash_function_from_moltype,
-};
+use crate::encoding::get_hash_function_from_moltype;
 use crate::errors::{IndexError, IndexResult};
-use crate::hp_alphabets::HpAlphabet;
 use crate::signature::{SignatureAccess, SEED};
 use crate::sketch::{ProteinSketch, ProteinSketchStore};
 
@@ -97,9 +93,6 @@ pub struct ProteomeIndex {
     // Amino acid ambiguity handler
     aa_ambiguity: Arc<AminoAcidAmbiguity>,
 
-    // Protein encoding function
-    encoding_fn: fn(u8) -> u8,
-
     // Statistics for k-mer frequencies and IDF
     // Not currently used, but will be used in the future
     #[allow(dead_code)]
@@ -123,6 +116,12 @@ pub struct ProteomeIndex {
 
     // Configuration for raw sequence storage
     store_raw_sequences: bool,
+
+    // Whether to drop low-complexity (homopolymer) k-mers when building protein
+    // signatures: raw amino-acid runs for any moltype, plus all-h/all-p runs for
+    // HP-family moltypes. Defaults to false. Persisted separately from the
+    // metadata blob; see save_state and read_remove_low_complexity.
+    remove_low_complexity: bool,
 }
 
 impl Drop for ProteomeIndex {
@@ -217,9 +216,6 @@ impl ProteomeIndex {
         let hash_function = get_hash_function_from_moltype(moltype)
             .map_err(|e| IndexError::SourmashError(e.to_string()))?;
 
-        let encoding_fn = get_encoding_fn_from_moltype(moltype)
-            .map_err(|e| IndexError::SourmashError(e.to_string()))?;
-
         let minhash_ksize = ksize * 3;
         // Create the minhash sketch
         let minhash = KmerMinHash::new(
@@ -242,14 +238,51 @@ impl ProteomeIndex {
             signatures: DashMap::new(),
             combined_minhash: Arc::new(Mutex::new(minhash)),
             aa_ambiguity: Arc::new(AminoAcidAmbiguity::new()),
-            encoding_fn,
             moltype: moltype.to_string(),
             ksize,
             minhash_ksize,
             scaled,
             stats: ProteomeIndexKmerStats { idf: HashMap::new(), frequency: HashMap::new() },
             store_raw_sequences,
+            remove_low_complexity: false,
         })
+    }
+
+    /// Enable or disable dropping low-complexity (homopolymer) k-mers when
+    /// building protein signatures. Defaults to `false`.
+    pub fn set_remove_low_complexity(&mut self, remove_low_complexity: bool) {
+        self.remove_low_complexity = remove_low_complexity;
+    }
+
+    /// Whether this index drops low-complexity (homopolymer) k-mers.
+    ///
+    /// Search reads this to build query sketches the same way the targets were
+    /// built; see `save_state` for why a mismatch skews containment.
+    pub fn remove_low_complexity(&self) -> bool {
+        self.remove_low_complexity
+    }
+
+    /// Total k-mer windows examined across all in-memory signatures, and how many
+    /// were removed as low-complexity. Returns `(0, 0)` when removal is off.
+    ///
+    /// Only meaningful right after indexing: the counts live on the in-memory
+    /// sketches and are not persisted.
+    pub fn low_complexity_counts(&self) -> (usize, usize) {
+        self.signatures.iter().fold((0, 0), |(examined, skipped), entry| {
+            let (e, s) = entry.value().low_complexity_counts();
+            (examined + e, skipped + s)
+        })
+    }
+
+    /// Read the persisted low-complexity removal setting from an open database.
+    ///
+    /// Indexes built before this flag existed have no such key, and were by
+    /// definition kept every k-mer, so a missing key reads as `false`.
+    fn read_remove_low_complexity(db: &DB) -> IndexResult<bool> {
+        match db.get(b"remove_low_complexity")? {
+            Some(data) => Ok(bincode::deserialize(&data)?),
+            None => Ok(false),
+        }
     }
 
     /// Get a reference to the signatures map (for testing)
@@ -743,8 +776,17 @@ impl ProteomeIndex {
         // deserializing the full metadata (and without breaking old bincode layouts).
         let serialized_version = bincode::serialize(&SCHEMA_VERSION)?;
         self.db.put(b"schema_version", serialized_version)?;
+
+        // Store the low-complexity removal setting as its own key, for the same reason:
+        // adding a field to ProteomeIndexMetadata would break bincode reads of indexes
+        // built before this flag existed. Absent key means "kept everything" (see
+        // read_remove_low_complexity), which is exactly right for those older indexes.
+        // WHY persist at all: search must build query sketches the same way, or
+        // retained low-complexity query k-mers inflate the containment denominator.
+        let serialized_filter = bincode::serialize(&self.remove_low_complexity)?;
+        self.db.put(b"remove_low_complexity", serialized_filter)?;
         eprintln!(
-            "[save] Metadata + schema_version written in {:.1}s total",
+            "[save] Metadata + schema_version + remove_low_complexity written in {:.1}s total",
             t3.elapsed().as_secs_f32()
         );
 
@@ -951,8 +993,6 @@ impl ProteomeIndex {
 
             let _hash_function = get_hash_function_from_moltype(&metadata.moltype)
                 .map_err(|e| IndexError::SourmashError(e.to_string()))?;
-            let encoding_fn = get_encoding_fn_from_moltype(&metadata.moltype)
-                .map_err(|e| IndexError::SourmashError(e.to_string()))?;
 
             // Reconstruct the combined minhash from raw data
             let hash_function = get_hash_function_from_moltype(&metadata.moltype)
@@ -998,6 +1038,7 @@ impl ProteomeIndex {
             let moltype = &metadata.moltype;
             let ksize = metadata.ksize;
             let scaled = metadata.scaled;
+            let remove_low_complexity = Self::read_remove_low_complexity(&db)?;
 
             let signatures: DashMap<String, ProteinSketch> = DashMap::new();
             raw_chunks.par_iter().try_for_each(|raw_data| -> IndexResult<()> {
@@ -1020,13 +1061,13 @@ impl ProteomeIndex {
                 signatures,
                 combined_minhash: Arc::new(Mutex::new(combined_minhash)),
                 aa_ambiguity: Arc::new(AminoAcidAmbiguity::new()),
-                encoding_fn,
                 moltype: metadata.moltype,
                 ksize: metadata.ksize,
                 minhash_ksize: metadata.ksize * 3,
                 scaled: metadata.scaled,
                 stats: ProteomeIndexKmerStats { idf: HashMap::new(), frequency: HashMap::new() },
                 store_raw_sequences: metadata.store_raw_sequences,
+                remove_low_complexity,
             };
 
             Ok(index)
@@ -1052,8 +1093,6 @@ impl ProteomeIndex {
         let metadata_data = db.get(b"index_metadata")?.ok_or(IndexError::NoSavedState)?;
         let metadata: ProteomeIndexMetadata = bincode::deserialize(&metadata_data)?;
 
-        let encoding_fn = get_encoding_fn_from_moltype(&metadata.moltype)
-            .map_err(|e| IndexError::SourmashError(e.to_string()))?;
         let hash_function = get_hash_function_from_moltype(&metadata.moltype)
             .map_err(|e| IndexError::SourmashError(e.to_string()))?;
         let minhash_ksize = metadata.ksize * 3;
@@ -1062,18 +1101,20 @@ impl ProteomeIndex {
         let combined_minhash =
             KmerMinHash::new(metadata.scaled, minhash_ksize, hash_function, SEED, true, 0);
 
+        let remove_low_complexity = Self::read_remove_low_complexity(&db)?;
+
         Ok(Self {
             db,
             signatures: DashMap::new(), // Empty - signatures loaded on demand by get_signature_by_md5()
             combined_minhash: Arc::new(Mutex::new(combined_minhash)),
             aa_ambiguity: Arc::new(AminoAcidAmbiguity::new()),
-            encoding_fn,
             moltype: metadata.moltype,
             ksize: metadata.ksize,
             minhash_ksize,
             scaled: metadata.scaled,
             stats: ProteomeIndexKmerStats { idf: HashMap::new(), frequency: HashMap::new() },
             store_raw_sequences: metadata.store_raw_sequences,
+            remove_low_complexity,
         })
     }
 
@@ -1262,10 +1303,16 @@ impl ProteomeIndex {
     }
 
     /// Generate a filename based on the index parameters
+    ///
+    /// WHY the `.nolowcomplexity` segment: the whole point of the flag is A/B
+    /// comparison, so indexing the same FASTA with and without it must not
+    /// resolve to the same path — otherwise the second run silently clobbers the
+    /// first. Indexes that keep every k-mer retain their historical filename.
     pub fn generate_filename(&self, base_name: &str) -> String {
+        let suffix = if self.remove_low_complexity { ".nolowcomplexity" } else { "" };
         format!(
-            "{}.{}.k{}.scaled{}.kmerseek.rocksdb",
-            base_name, self.moltype, self.ksize, self.scaled
+            "{}.{}.k{}.scaled{}{}.kmerseek.rocksdb",
+            base_name, self.moltype, self.ksize, self.scaled, suffix
         )
     }
 
@@ -1344,6 +1391,7 @@ impl ProteomeIndex {
 
         // Create a new protein signature
         let mut protein_sig = ProteinSketch::new(name, self.ksize, self.scaled, &self.moltype)?;
+        protein_sig.set_remove_low_complexity(self.remove_low_complexity);
 
         // Add the protein sequence to the signature
         // WHY: add_protein now handles all processing: minhash, kmer_infos, and sequence storage.
@@ -1355,46 +1403,6 @@ impl ProteomeIndex {
 
         // Return the processed signature (don't store it yet)
         Ok(protein_sig)
-    }
-
-    pub fn process_kmers(
-        &self,
-        sequence: &str,
-        protein_signature: &mut ProteinSketch,
-    ) -> IndexResult<()> {
-        let ksize = self.ksize as usize;
-        let hashvals: HashSet<u64> =
-            protein_signature.signature().get_minhash().to_vec().into_iter().collect();
-
-        let custom_hp = HpAlphabet::from_moltype(&self.moltype);
-        for i in 0..sequence.len().saturating_sub(ksize - 1) {
-            let kmer = &sequence[i..i + ksize];
-            // WHY: sourmash's ReadingFrame::new_protein uppercases before hashing.
-            let hashval = if let Some(ref alpha) = custom_hp {
-                let encoded: Vec<u8> = kmer
-                    .bytes()
-                    .map(|b| {
-                        alpha
-                            .table()
-                            .get(&b.to_ascii_uppercase())
-                            .copied()
-                            .unwrap_or(b)
-                            .to_ascii_uppercase()
-                    })
-                    .collect();
-                _hash_murmur(&encoded, SEED)
-            } else {
-                match encode_with_fn(kmer, self.encoding_fn) {
-                    Ok(enc) => _hash_murmur(enc.to_ascii_uppercase().as_bytes(), SEED),
-                    Err(_) => continue,
-                }
-            };
-            if hashvals.contains(&hashval) {
-                protein_signature.kmer_positions_mut().entry(hashval).or_default().push(i);
-            }
-        }
-
-        Ok(())
     }
 
     /// Store a collection of protein signatures in the index
@@ -1764,7 +1772,7 @@ mod tests {
     /// than unit tests with all the moltype testing. Also, it's a lot of tests!
 
     #[test]
-    fn test_process_kmers_moltype_protein() -> Result<()> {
+    fn test_add_protein_moltype_protein() -> Result<()> {
         let _dir = tempdir()?;
 
         let protein_ksize = 5;
@@ -1833,7 +1841,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_kmers_moltype_dayhoff() -> Result<()> {
+    fn test_add_protein_moltype_dayhoff() -> Result<()> {
         let _dir = tempdir()?;
 
         let protein_ksize = 5;
@@ -1902,7 +1910,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_kmers_moltype_hp() -> Result<()> {
+    fn test_add_protein_moltype_hp() -> Result<()> {
         let _dir = tempdir()?;
 
         let protein_ksize = 5;
@@ -2120,6 +2128,96 @@ mod tests {
             let combined_minhash = index.get_combined_minhash().lock();
             assert!(combined_minhash.size() == 14, "Combined minhash should contain 14 hashes");
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remove_low_complexity_toggle_on_index() -> Result<()> {
+        let dir = tempdir()?;
+
+        let protein_ksize = 5;
+        let moltype = "hp";
+        let sequence = TEST_PROTEIN;
+        let name = "test_protein";
+
+        // TEST_PROTEIN = "PLANTANDANIMALGENQMES"; window 10, "IMALG", is
+        // all-hydrophobic ("hhhhh") under the HP (Lehninger) alphabet.
+        const IMALG_HASH: u64 = 8541583772724823208;
+
+        // Default: removal is off, so the low-complexity k-mer is kept.
+        let index_off = ProteomeIndex::new(
+            dir.path().join("removal_off.db"),
+            protein_ksize,
+            1,
+            moltype,
+            false,
+        )?;
+        let sig_off = index_off.create_protein_signature(sequence, name)?;
+        assert_eq!(sig_off.kmer_positions().len(), 14);
+        assert!(sig_off.kmer_positions().contains_key(&IMALG_HASH));
+
+        // Opted in via set_remove_low_complexity: the low-complexity k-mer is dropped.
+        let mut index_on =
+            ProteomeIndex::new(dir.path().join("removal_on.db"), protein_ksize, 1, moltype, false)?;
+        index_on.set_remove_low_complexity(true);
+        let sig_on = index_on.create_protein_signature(sequence, name)?;
+        assert_eq!(sig_on.kmer_positions().len(), 13);
+        assert!(!sig_on.kmer_positions().contains_key(&IMALG_HASH));
+
+        Ok(())
+    }
+
+    /// The setting must survive save_state -> open_for_search, since search
+    /// relies on it to build query sketches the same way the targets were built.
+    #[test]
+    fn test_remove_low_complexity_persists_across_save_and_reopen() -> Result<()> {
+        let dir = tempdir()?;
+
+        for flag in [true, false] {
+            let db_path = dir.path().join(format!("persist_{}.db", flag));
+            {
+                let mut index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+                index.set_remove_low_complexity(flag);
+                let sig = index.create_protein_signature(TEST_PROTEIN, "p")?;
+                index.store_signatures(vec![sig])?;
+                index.save_state()?;
+            }
+
+            let reopened = ProteomeIndex::open_for_search(&db_path)?;
+            assert_eq!(
+                reopened.remove_low_complexity(),
+                flag,
+                "remove_low_complexity should round-trip through the database"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Indexes written before this flag existed have no such key; they were
+    /// kept every k-mer by definition, so a missing key must read as false rather
+    /// than erroring out.
+    #[test]
+    fn test_missing_remove_low_complexity_key_reads_as_false() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("legacy.db");
+        {
+            let index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+            let sig = index.create_protein_signature(TEST_PROTEIN, "p")?;
+            index.store_signatures(vec![sig])?;
+            index.save_state()?;
+        }
+
+        // Simulate a pre-flag index by deleting the key save_state wrote.
+        {
+            use rocksdb::{Options, DB};
+            let db = DB::open(&Options::default(), &db_path)?;
+            db.delete(b"remove_low_complexity")?;
+        }
+
+        let reopened = ProteomeIndex::open_for_search(&db_path)?;
+        assert!(!reopened.remove_low_complexity());
 
         Ok(())
     }
@@ -3570,6 +3668,7 @@ pub struct ProteomeIndexBuilder {
     scaled: Option<u32>,
     moltype: Option<String>,
     store_raw_sequences: bool,
+    remove_low_complexity: bool,
 }
 
 impl ProteomeIndexBuilder {
@@ -3608,6 +3707,12 @@ impl ProteomeIndexBuilder {
         self
     }
 
+    /// Set whether to drop low-complexity (homopolymer) k-mers (defaults to false)
+    pub fn remove_low_complexity(mut self, remove_low_complexity: bool) -> Self {
+        self.remove_low_complexity = remove_low_complexity;
+        self
+    }
+
     /// Build the ProteomeIndex
     pub fn build(self) -> IndexResult<ProteomeIndex> {
         let path = self
@@ -3623,7 +3728,10 @@ impl ProteomeIndexBuilder {
             .moltype
             .ok_or_else(|| IndexError::BuilderError("Molecular type is required".to_string()))?;
 
-        ProteomeIndex::new(path, ksize, scaled, &moltype, self.store_raw_sequences)
+        let mut index =
+            ProteomeIndex::new(path, ksize, scaled, &moltype, self.store_raw_sequences)?;
+        index.set_remove_low_complexity(self.remove_low_complexity);
+        Ok(index)
     }
 
     /// Build the ProteomeIndex with automatic filename generation
@@ -3641,12 +3749,14 @@ impl ProteomeIndexBuilder {
             .moltype
             .ok_or_else(|| IndexError::BuilderError("Molecular type is required".to_string()))?;
 
-        ProteomeIndex::new_with_auto_filename(
+        let mut index = ProteomeIndex::new_with_auto_filename(
             base_path,
             ksize,
             scaled,
             &moltype,
             self.store_raw_sequences,
-        )
+        )?;
+        index.set_remove_low_complexity(self.remove_low_complexity);
+        Ok(index)
     }
 }

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -2320,8 +2320,10 @@ mod tests {
             .scaled(1)
             .moltype("hp")
             .remove_low_complexity(true)
+            .store_raw_sequences(true)
             .build()?;
         assert!(on.remove_low_complexity());
+        assert!(on.store_raw_sequences());
 
         // Defaults to false when the builder method is not called.
         let off = ProteomeIndex::builder()
@@ -2367,44 +2369,131 @@ mod tests {
     /// than erroring out.
     #[test]
     fn test_unversioned_index_reads_through_legacy_metadata_layout() -> Result<()> {
+        // Two flavors of old index: one written at schema 1, and one predating
+        // schema versioning entirely (no key, which reads as version 0).
+        for rolled_back in [true, false] {
+            let dir = tempdir()?;
+            let db_path = dir.path().join("legacy.db");
+            {
+                let index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+                let sig = index.create_protein_signature(TEST_PROTEIN, "p")?;
+                index.store_signatures(vec![sig])?;
+                index.save_state()?;
+            }
+
+            // Rewrite the index as a pre-versioning one: metadata in the old 8-field
+            // layout, and no kmerseek_version key.
+            {
+                use rocksdb::{Options, DB};
+                let db = DB::open(&Options::default(), &db_path)?;
+                let current: ProteomeIndexMetadata =
+                    bincode::deserialize(&db.get(b"index_metadata")?.unwrap())?;
+                let legacy = LegacyProteomeIndexMetadata {
+                    total_signatures: current.total_signatures,
+                    chunk_count: current.chunk_count,
+                    combined_mins: current.combined_mins,
+                    combined_abunds: current.combined_abunds,
+                    moltype: current.moltype,
+                    ksize: current.ksize,
+                    scaled: current.scaled,
+                    store_raw_sequences: current.store_raw_sequences,
+                };
+                db.put(b"index_metadata", bincode::serialize(&legacy)?)?;
+                db.delete(KMERSEEK_VERSION_KEY)?;
+                // Layout is selected by schema_version, so roll that back too --
+                // deleting the provenance key alone would not make this a v1 index.
+                if rolled_back {
+                    db.put(b"schema_version", bincode::serialize(&1u32)?)?;
+                } else {
+                    // Truly ancient: no schema_version key at all, which reads as 0.
+                    db.delete(b"schema_version")?;
+                }
+            }
+
+            // The legacy layout still loads, and defaults the flag to false.
+            let reopened = ProteomeIndex::open_for_search(&db_path)?;
+            assert!(!reopened.remove_low_complexity());
+            assert_eq!(reopened.ksize(), 5);
+            assert_eq!(reopened.moltype(), "hp");
+            // No version was ever stamped on these.
+            assert_eq!(reopened.kmerseek_version(), None);
+        }
+
+        Ok(())
+    }
+
+    /// `load_state` rehydrates signatures into an existing index handle, a
+    /// separate path from `load` (which builds a fresh index) -- search uses it.
+    #[test]
+    fn test_load_state_rehydrates_signatures_into_existing_index() -> Result<()> {
         let dir = tempdir()?;
-        let db_path = dir.path().join("legacy.db");
+        let db_path = dir.path().join("load_state.db");
         {
             let index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+            for (name, seq) in [("p1", TEST_PROTEIN), ("p2", FKBP8_POLY_E)] {
+                let sig = index.create_protein_signature(seq, name)?;
+                index.store_signatures(vec![sig])?;
+            }
+            index.save_state()?;
+        }
+
+        let index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+        assert_eq!(index.signature_count(), 0, "a fresh handle starts empty");
+        index.load_state()?;
+        assert_eq!(index.signature_count(), 2, "load_state should pull both signatures back");
+
+        Ok(())
+    }
+
+    /// The full in-memory load path (as opposed to `open_for_search`) must also
+    /// recover the flag and the version, and bring the signatures back with it.
+    #[test]
+    fn test_load_round_trips_flag_version_and_signatures() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("full_load.db");
+        {
+            let mut index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+            index.set_remove_low_complexity(true);
+            for (name, seq) in [("p1", TEST_PROTEIN), ("p2", FKBP8_POLY_E)] {
+                let sig = index.create_protein_signature(seq, name)?;
+                index.store_signatures(vec![sig])?;
+            }
+            index.save_state()?;
+        }
+        // Dropped above, so RocksDB's lock is released before reopening.
+
+        let loaded = ProteomeIndex::load(&db_path)?;
+        assert!(loaded.remove_low_complexity());
+        assert_eq!(loaded.kmerseek_version(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(loaded.signature_count(), 2);
+        assert_eq!(loaded.ksize(), 5);
+        assert_eq!(loaded.scaled(), 1);
+        assert_eq!(loaded.moltype(), "hp");
+
+        // Counts are per-process build state, not persisted, so a fresh load
+        // starts at zero rather than inheriting the writer's totals.
+        assert_eq!(loaded.low_complexity_counts(), (0, 0));
+
+        Ok(())
+    }
+
+    /// `get_index_parameters` is what the search CLI uses to autodetect settings
+    /// from a database, and it reads the schema version on the way through.
+    #[test]
+    fn test_get_index_parameters_reads_from_saved_index() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("params.db");
+        {
+            let index = ProteomeIndex::new(&db_path, 7, 1, "dayhoff", true)?;
             let sig = index.create_protein_signature(TEST_PROTEIN, "p")?;
             index.store_signatures(vec![sig])?;
             index.save_state()?;
         }
 
-        // Rewrite the index as a pre-versioning one: metadata in the old 8-field
-        // layout, and no kmerseek_version key.
-        {
-            use rocksdb::{Options, DB};
-            let db = DB::open(&Options::default(), &db_path)?;
-            let current: ProteomeIndexMetadata =
-                bincode::deserialize(&db.get(b"index_metadata")?.unwrap())?;
-            let legacy = LegacyProteomeIndexMetadata {
-                total_signatures: current.total_signatures,
-                chunk_count: current.chunk_count,
-                combined_mins: current.combined_mins,
-                combined_abunds: current.combined_abunds,
-                moltype: current.moltype,
-                ksize: current.ksize,
-                scaled: current.scaled,
-                store_raw_sequences: current.store_raw_sequences,
-            };
-            db.put(b"index_metadata", bincode::serialize(&legacy)?)?;
-            db.delete(KMERSEEK_VERSION_KEY)?;
-            // Layout is selected by schema_version, so roll that back too --
-            // deleting the provenance key alone would not make this a v1 index.
-            db.put(b"schema_version", bincode::serialize(&1u32)?)?;
-        }
-
-        // The legacy layout still loads, and defaults the flag to false.
-        let reopened = ProteomeIndex::open_for_search(&db_path)?;
-        assert!(!reopened.remove_low_complexity());
-        assert_eq!(reopened.ksize(), 5);
-        assert_eq!(reopened.moltype(), "hp");
+        let (ksize, scaled, moltype) = ProteomeIndex::get_index_parameters(&db_path)?;
+        assert_eq!(ksize, 7);
+        assert_eq!(scaled, 1);
+        assert_eq!(moltype, "dayhoff");
 
         Ok(())
     }

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -32,7 +32,7 @@ use crate::sketch::{ProteinSketch, ProteinSketchStore};
 /// and will be rejected with a clear error message asking the user to rebuild.
 pub const SCHEMA_VERSION: u32 = 2;
 
-/// RocksDB key holding the kmerseek version that wrote the index, e.g. "0.4.0".
+/// RocksDB key holding the kmerseek version that wrote the index, e.g. `"0.4.0"`.
 /// Provenance only; `schema_version` is what selects the on-disk layout.
 const KMERSEEK_VERSION_KEY: &[u8] = b"kmerseek_version";
 
@@ -73,8 +73,8 @@ struct ProteomeIndexMetadata {
     scaled: u32,
     store_raw_sequences: bool,
     /// Whether low-complexity k-mers were removed when this index was built.
-    /// Appended after the fields above, so only indexes carrying a
-    /// `kmerseek_version` key have it; see `read_metadata`.
+    /// Present from schema 2 onward; older layouts are read through
+    /// `LegacyProteomeIndexMetadata`. See `read_metadata`.
     remove_low_complexity: bool,
 }
 
@@ -173,6 +173,12 @@ pub struct ProteomeIndex {
     // Running totals accumulated as signatures are built, rather than by walking
     // every signature afterwards. Atomic because create_protein_signature takes
     // &self and process_fasta drives it from a par_iter.
+    //
+    // Relaxed ordering is sufficient and deliberate: these are counters only, and
+    // no other data is published through them. Callers read them after the
+    // par_iter has finished, and rayon's join already establishes happens-before
+    // between the workers and the caller, so every increment is visible by then.
+    // Reading mid-run would just yield a partial count, never a torn value.
     kmer_windows_examined: AtomicUsize,
     low_complexity_kmers_removed: AtomicUsize,
 
@@ -2364,9 +2370,9 @@ mod tests {
         Ok(())
     }
 
-    /// Indexes written before this flag existed have no such key; they were
-    /// kept every k-mer by definition, so a missing key must read as false rather
-    /// than erroring out.
+    /// An index older than schema 2 has no `remove_low_complexity` field in its
+    /// metadata. It must still load, with the flag reading `false`, since such an
+    /// index kept every k-mer by definition.
     #[test]
     fn test_unversioned_index_reads_through_legacy_metadata_layout() -> Result<()> {
         // Two flavors of old index: one written at schema 1, and one predating
@@ -2498,8 +2504,7 @@ mod tests {
         Ok(())
     }
 
-    /// Indexes written now carry the kmerseek version, both as provenance and as
-    /// the marker for the current metadata layout.
+    /// Saved indexes record which kmerseek version wrote them.
     #[test]
     fn test_save_state_stamps_kmerseek_version() -> Result<()> {
         let dir = tempdir()?;

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -33,11 +33,12 @@ use crate::sketch::{ProteinSketch, ProteinSketchStore};
 pub const SCHEMA_VERSION: u32 = 2;
 
 /// RocksDB key holding the kmerseek version that wrote the index, e.g. "0.4.0".
-///
-/// Doubles as the marker for the current metadata layout: an index carrying this
-/// key has a `remove_low_complexity` field in its metadata, one without it does
-/// not. See `read_metadata`.
+/// Provenance only; `schema_version` is what selects the on-disk layout.
 const KMERSEEK_VERSION_KEY: &[u8] = b"kmerseek_version";
+
+/// First schema version whose metadata carries `remove_low_complexity`.
+/// Indexes older than this are read through `LegacyProteomeIndexMetadata`.
+const SCHEMA_VERSION_WITH_REMOVE_LOW_COMPLEXITY: u32 = 2;
 
 /// Statistics for k-mer frequency analysis
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -174,6 +175,11 @@ pub struct ProteomeIndex {
     // &self and process_fasta drives it from a par_iter.
     kmer_windows_examined: AtomicUsize,
     low_complexity_kmers_removed: AtomicUsize,
+
+    // kmerseek version that wrote this index on disk, if it was stamped.
+    // None for a freshly constructed index (nothing saved yet) and for indexes
+    // built before version stamping existed.
+    kmerseek_version: Option<String>,
 }
 
 impl Drop for ProteomeIndex {
@@ -299,6 +305,7 @@ impl ProteomeIndex {
             remove_low_complexity: false,
             kmer_windows_examined: AtomicUsize::new(0),
             low_complexity_kmers_removed: AtomicUsize::new(0),
+            kmerseek_version: None,
         })
     }
 
@@ -306,6 +313,15 @@ impl ProteomeIndex {
     /// building protein signatures. Defaults to `false`.
     pub fn set_remove_low_complexity(&mut self, remove_low_complexity: bool) {
         self.remove_low_complexity = remove_low_complexity;
+    }
+
+    /// The kmerseek version that wrote this index, e.g. `"0.4.0"`.
+    ///
+    /// `None` for an index built before version stamping, or one not yet saved.
+    /// Useful for diagnosing behavior differences between an index and the binary
+    /// querying it.
+    pub fn kmerseek_version(&self) -> Option<&str> {
+        self.kmerseek_version.as_deref()
     }
 
     /// Whether this index drops low-complexity (homopolymer) k-mers.
@@ -329,24 +345,34 @@ impl ProteomeIndex {
         )
     }
 
-    /// The kmerseek version that wrote an index, if it was stamped.
+    /// The kmerseek version that wrote an index, e.g. "0.4.0".
     ///
-    /// `None` for indexes built before version stamping was added.
-    pub fn read_kmerseek_version(db: &DB) -> IndexResult<Option<String>> {
+    /// `None` for indexes built before version stamping was added. Purely
+    /// provenance -- the on-disk layout is keyed off `schema_version`, not this,
+    /// because a semver string is not a usable layout discriminator.
+    fn read_kmerseek_version(db: &DB) -> IndexResult<Option<String>> {
         match db.get(KMERSEEK_VERSION_KEY)? {
             Some(data) => Ok(Some(bincode::deserialize(&data)?)),
             None => Ok(None),
         }
     }
 
-    /// Deserialize index metadata, picking the layout by whether the index was
-    /// stamped with a kmerseek version.
+    /// Schema version an index was written with. Absent means pre-versioning, i.e. 0.
+    fn read_schema_version(db: &DB) -> IndexResult<u32> {
+        match db.get(b"schema_version")? {
+            Some(data) => Ok(bincode::deserialize(&data)?),
+            None => Ok(0),
+        }
+    }
+
+    /// Deserialize index metadata, picking the layout by schema version.
     ///
-    /// Versioned indexes use the current layout. Unversioned ones predate the
-    /// `remove_low_complexity` field and are read through the legacy struct, which
-    /// defaults it to `false` -- correct, since they kept every k-mer.
+    /// bincode is not self-describing, so the layout has to be known up front.
+    /// Schema 2 added `remove_low_complexity` to the metadata; anything older is
+    /// read through the legacy struct, which defaults it to `false` -- correct,
+    /// since those indexes kept every k-mer.
     fn read_metadata(db: &DB, raw: &[u8]) -> IndexResult<ProteomeIndexMetadata> {
-        if Self::read_kmerseek_version(db)?.is_some() {
+        if Self::read_schema_version(db)? >= SCHEMA_VERSION_WITH_REMOVE_LOW_COMPLEXITY {
             Ok(bincode::deserialize(raw)?)
         } else {
             let legacy: LegacyProteomeIndexMetadata = bincode::deserialize(raw)?;
@@ -1104,6 +1130,8 @@ impl ProteomeIndex {
             let ksize = metadata.ksize;
             let scaled = metadata.scaled;
             let remove_low_complexity = metadata.remove_low_complexity;
+            // Read before `db` is moved into the struct below.
+            let kmerseek_version = Self::read_kmerseek_version(&db)?;
 
             let signatures: DashMap<String, ProteinSketch> = DashMap::new();
             raw_chunks.par_iter().try_for_each(|raw_data| -> IndexResult<()> {
@@ -1135,6 +1163,7 @@ impl ProteomeIndex {
                 remove_low_complexity,
                 kmer_windows_examined: AtomicUsize::new(0),
                 low_complexity_kmers_removed: AtomicUsize::new(0),
+                kmerseek_version,
             };
 
             Ok(index)
@@ -1169,6 +1198,7 @@ impl ProteomeIndex {
             KmerMinHash::new(metadata.scaled, minhash_ksize, hash_function, SEED, true, 0);
 
         let remove_low_complexity = metadata.remove_low_complexity;
+        let kmerseek_version = Self::read_kmerseek_version(&db)?;
 
         Ok(Self {
             db,
@@ -1184,6 +1214,7 @@ impl ProteomeIndex {
             remove_low_complexity,
             kmer_windows_examined: AtomicUsize::new(0),
             low_complexity_kmers_removed: AtomicUsize::new(0),
+            kmerseek_version,
         })
     }
 
@@ -1249,10 +1280,7 @@ impl ProteomeIndex {
         // format and are fully compatible with schema version 1. We accept them here.
         // Only truly incompatible formats (e.g., pre-Feb-24 kmer_infos format) need rebuilding,
         // but those can't be detected by this key alone.
-        let stored_version: u32 = match db.get(b"schema_version")? {
-            Some(data) => bincode::deserialize(&data)?,
-            None => 0, // pre-versioning index
-        };
+        let stored_version = Self::read_schema_version(&db)?;
         if stored_version > SCHEMA_VERSION {
             return Err(IndexError::ValidationError {
                 message: format!(
@@ -2367,6 +2395,9 @@ mod tests {
             };
             db.put(b"index_metadata", bincode::serialize(&legacy)?)?;
             db.delete(KMERSEEK_VERSION_KEY)?;
+            // Layout is selected by schema_version, so roll that back too --
+            // deleting the provenance key alone would not make this a v1 index.
+            db.put(b"schema_version", bincode::serialize(&1u32)?)?;
         }
 
         // The legacy layout still loads, and defaults the flag to false.
@@ -2382,7 +2413,6 @@ mod tests {
     /// the marker for the current metadata layout.
     #[test]
     fn test_save_state_stamps_kmerseek_version() -> Result<()> {
-        use rocksdb::{Options, DB};
         let dir = tempdir()?;
         let db_path = dir.path().join("versioned.db");
         {
@@ -2392,11 +2422,8 @@ mod tests {
             index.save_state()?;
         }
 
-        let db = DB::open(&Options::default(), &db_path)?;
-        assert_eq!(
-            ProteomeIndex::read_kmerseek_version(&db)?,
-            Some(env!("CARGO_PKG_VERSION").to_string())
-        );
+        let reopened = ProteomeIndex::open_for_search(&db_path)?;
+        assert_eq!(reopened.kmerseek_version(), Some(env!("CARGO_PKG_VERSION")));
 
         Ok(())
     }

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -30,6 +31,13 @@ use crate::sketch::{ProteinSketch, ProteinSketchStore};
 /// Indices that predate versioning (schema_version key absent) are treated as version 0
 /// and will be rejected with a clear error message asking the user to rebuild.
 pub const SCHEMA_VERSION: u32 = 2;
+
+/// RocksDB key holding the kmerseek version that wrote the index, e.g. "0.4.0".
+///
+/// Doubles as the marker for the current metadata layout: an index carrying this
+/// key has a `remove_low_complexity` field in its metadata, one without it does
+/// not. See `read_metadata`.
+const KMERSEEK_VERSION_KEY: &[u8] = b"kmerseek_version";
 
 /// Statistics for k-mer frequency analysis
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,6 +71,44 @@ struct ProteomeIndexMetadata {
     ksize: u32,
     scaled: u32,
     store_raw_sequences: bool,
+    /// Whether low-complexity k-mers were removed when this index was built.
+    /// Appended after the fields above, so only indexes carrying a
+    /// `kmerseek_version` key have it; see `read_metadata`.
+    remove_low_complexity: bool,
+}
+
+/// The metadata layout used before `kmerseek_version` was stamped into indexes.
+///
+/// bincode is not self-describing, so an older blob cannot be deserialized into
+/// the current `ProteomeIndexMetadata` -- it would run out of bytes on the
+/// trailing field. Indexes without a version key are read through this instead.
+#[derive(Serialize, Deserialize)]
+struct LegacyProteomeIndexMetadata {
+    total_signatures: usize,
+    chunk_count: usize,
+    combined_mins: Vec<u64>,
+    combined_abunds: Option<Vec<u64>>,
+    moltype: String,
+    ksize: u32,
+    scaled: u32,
+    store_raw_sequences: bool,
+}
+
+impl From<LegacyProteomeIndexMetadata> for ProteomeIndexMetadata {
+    fn from(legacy: LegacyProteomeIndexMetadata) -> Self {
+        Self {
+            total_signatures: legacy.total_signatures,
+            chunk_count: legacy.chunk_count,
+            combined_mins: legacy.combined_mins,
+            combined_abunds: legacy.combined_abunds,
+            moltype: legacy.moltype,
+            ksize: legacy.ksize,
+            scaled: legacy.scaled,
+            store_raw_sequences: legacy.store_raw_sequences,
+            // Predates the flag, so by definition every k-mer was kept.
+            remove_low_complexity: false,
+        }
+    }
 }
 
 /// Serializable search cache built at index time for fast search startup.
@@ -122,6 +168,12 @@ pub struct ProteomeIndex {
     // HP-family moltypes. Defaults to false. Persisted separately from the
     // metadata blob; see save_state and read_remove_low_complexity.
     remove_low_complexity: bool,
+
+    // Running totals accumulated as signatures are built, rather than by walking
+    // every signature afterwards. Atomic because create_protein_signature takes
+    // &self and process_fasta drives it from a par_iter.
+    kmer_windows_examined: AtomicUsize,
+    low_complexity_kmers_removed: AtomicUsize,
 }
 
 impl Drop for ProteomeIndex {
@@ -245,6 +297,8 @@ impl ProteomeIndex {
             stats: ProteomeIndexKmerStats { idf: HashMap::new(), frequency: HashMap::new() },
             store_raw_sequences,
             remove_low_complexity: false,
+            kmer_windows_examined: AtomicUsize::new(0),
+            low_complexity_kmers_removed: AtomicUsize::new(0),
         })
     }
 
@@ -262,26 +316,41 @@ impl ProteomeIndex {
         self.remove_low_complexity
     }
 
-    /// Total k-mer windows examined across all in-memory signatures, and how many
-    /// were removed as low-complexity. Returns `(0, 0)` when removal is off.
+    /// Total k-mer windows examined while building signatures, and how many were
+    /// removed as low-complexity. Returns `(0, 0)` when removal is off.
     ///
-    /// Only meaningful right after indexing: the counts live on the in-memory
-    /// sketches and are not persisted.
+    /// Accumulated as each signature is built rather than by walking the whole
+    /// signature map afterwards, so reading this is O(1) and adds no extra pass
+    /// over the data. Not persisted; meaningful only for the current process.
     pub fn low_complexity_counts(&self) -> (usize, usize) {
-        self.signatures.iter().fold((0, 0), |(examined, skipped), entry| {
-            let (e, s) = entry.value().low_complexity_counts();
-            (examined + e, skipped + s)
-        })
+        (
+            self.kmer_windows_examined.load(Ordering::Relaxed),
+            self.low_complexity_kmers_removed.load(Ordering::Relaxed),
+        )
     }
 
-    /// Read the persisted low-complexity removal setting from an open database.
+    /// The kmerseek version that wrote an index, if it was stamped.
     ///
-    /// Indexes built before this flag existed have no such key, and were by
-    /// definition kept every k-mer, so a missing key reads as `false`.
-    fn read_remove_low_complexity(db: &DB) -> IndexResult<bool> {
-        match db.get(b"remove_low_complexity")? {
-            Some(data) => Ok(bincode::deserialize(&data)?),
-            None => Ok(false),
+    /// `None` for indexes built before version stamping was added.
+    pub fn read_kmerseek_version(db: &DB) -> IndexResult<Option<String>> {
+        match db.get(KMERSEEK_VERSION_KEY)? {
+            Some(data) => Ok(Some(bincode::deserialize(&data)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Deserialize index metadata, picking the layout by whether the index was
+    /// stamped with a kmerseek version.
+    ///
+    /// Versioned indexes use the current layout. Unversioned ones predate the
+    /// `remove_low_complexity` field and are read through the legacy struct, which
+    /// defaults it to `false` -- correct, since they kept every k-mer.
+    fn read_metadata(db: &DB, raw: &[u8]) -> IndexResult<ProteomeIndexMetadata> {
+        if Self::read_kmerseek_version(db)?.is_some() {
+            Ok(bincode::deserialize(raw)?)
+        } else {
+            let legacy: LegacyProteomeIndexMetadata = bincode::deserialize(raw)?;
+            Ok(legacy.into())
         }
     }
 
@@ -762,6 +831,7 @@ impl ProteomeIndex {
             ksize: self.ksize,
             scaled: self.scaled,
             store_raw_sequences: self.store_raw_sequences,
+            remove_low_complexity: self.remove_low_complexity,
         };
 
         let serialized_metadata = bincode::serialize(&metadata)?;
@@ -777,16 +847,11 @@ impl ProteomeIndex {
         let serialized_version = bincode::serialize(&SCHEMA_VERSION)?;
         self.db.put(b"schema_version", serialized_version)?;
 
-        // Store the low-complexity removal setting as its own key, for the same reason:
-        // adding a field to ProteomeIndexMetadata would break bincode reads of indexes
-        // built before this flag existed. Absent key means "kept everything" (see
-        // read_remove_low_complexity), which is exactly right for those older indexes.
-        // WHY persist at all: search must build query sketches the same way, or
-        // retained low-complexity query k-mers inflate the containment denominator.
-        let serialized_filter = bincode::serialize(&self.remove_low_complexity)?;
-        self.db.put(b"remove_low_complexity", serialized_filter)?;
+        // Stamp the writing kmerseek version. Besides being useful provenance, its
+        // presence tells readers the metadata carries a remove_low_complexity field.
+        self.db.put(KMERSEEK_VERSION_KEY, bincode::serialize(env!("CARGO_PKG_VERSION"))?)?;
         eprintln!(
-            "[save] Metadata + schema_version + remove_low_complexity written in {:.1}s total",
+            "[save] Metadata + schema_version + kmerseek_version written in {:.1}s total",
             t3.elapsed().as_secs_f32()
         );
 
@@ -829,7 +894,7 @@ impl ProteomeIndex {
         // Try to load from new chunked format first
         let metadata_serialized = self.db.get(b"index_metadata")?;
         if let Some(metadata_data) = metadata_serialized {
-            let metadata: ProteomeIndexMetadata = bincode::deserialize(&metadata_data)?;
+            let metadata = Self::read_metadata(&self.db, &metadata_data)?;
 
             // Load all chunk data from RocksDB (sequential)
             let mut raw_chunks: Vec<Vec<u8>> = Vec::with_capacity(metadata.chunk_count);
@@ -989,7 +1054,7 @@ impl ProteomeIndex {
         // Try to load state to get configuration
         let serialized = db.get(b"index_metadata")?;
         if let Some(data) = serialized {
-            let metadata: ProteomeIndexMetadata = bincode::deserialize(&data)?;
+            let metadata = Self::read_metadata(&db, &data)?;
 
             let _hash_function = get_hash_function_from_moltype(&metadata.moltype)
                 .map_err(|e| IndexError::SourmashError(e.to_string()))?;
@@ -1038,7 +1103,7 @@ impl ProteomeIndex {
             let moltype = &metadata.moltype;
             let ksize = metadata.ksize;
             let scaled = metadata.scaled;
-            let remove_low_complexity = Self::read_remove_low_complexity(&db)?;
+            let remove_low_complexity = metadata.remove_low_complexity;
 
             let signatures: DashMap<String, ProteinSketch> = DashMap::new();
             raw_chunks.par_iter().try_for_each(|raw_data| -> IndexResult<()> {
@@ -1068,6 +1133,8 @@ impl ProteomeIndex {
                 stats: ProteomeIndexKmerStats { idf: HashMap::new(), frequency: HashMap::new() },
                 store_raw_sequences: metadata.store_raw_sequences,
                 remove_low_complexity,
+                kmer_windows_examined: AtomicUsize::new(0),
+                low_complexity_kmers_removed: AtomicUsize::new(0),
             };
 
             Ok(index)
@@ -1091,7 +1158,7 @@ impl ProteomeIndex {
         let db = DB::open_for_read_only(&opts, path, false)?;
 
         let metadata_data = db.get(b"index_metadata")?.ok_or(IndexError::NoSavedState)?;
-        let metadata: ProteomeIndexMetadata = bincode::deserialize(&metadata_data)?;
+        let metadata = Self::read_metadata(&db, &metadata_data)?;
 
         let hash_function = get_hash_function_from_moltype(&metadata.moltype)
             .map_err(|e| IndexError::SourmashError(e.to_string()))?;
@@ -1101,7 +1168,7 @@ impl ProteomeIndex {
         let combined_minhash =
             KmerMinHash::new(metadata.scaled, minhash_ksize, hash_function, SEED, true, 0);
 
-        let remove_low_complexity = Self::read_remove_low_complexity(&db)?;
+        let remove_low_complexity = metadata.remove_low_complexity;
 
         Ok(Self {
             db,
@@ -1115,6 +1182,8 @@ impl ProteomeIndex {
             stats: ProteomeIndexKmerStats { idf: HashMap::new(), frequency: HashMap::new() },
             store_raw_sequences: metadata.store_raw_sequences,
             remove_low_complexity,
+            kmer_windows_examined: AtomicUsize::new(0),
+            low_complexity_kmers_removed: AtomicUsize::new(0),
         })
     }
 
@@ -1198,7 +1267,7 @@ impl ProteomeIndex {
         // Try to load metadata from new chunked format first
         let metadata_serialized = db.get(b"index_metadata")?;
         if let Some(metadata_data) = metadata_serialized {
-            let metadata: ProteomeIndexMetadata = bincode::deserialize(&metadata_data)?;
+            let metadata = Self::read_metadata(&db, &metadata_data)?;
             return Ok((metadata.ksize, metadata.scaled, metadata.moltype));
         }
 
@@ -1400,6 +1469,14 @@ impl ProteomeIndex {
         // only stored in memory if they will be saved to disk, preventing memory waste and
         // ensuring search operations work correctly.
         protein_sig.add_protein(&processed_sequence, self.store_raw_sequences)?;
+
+        // Fold this sequence's tallies in now, while the sketch is already in
+        // hand, so no later pass over the signature map is needed.
+        let (examined, removed) = protein_sig.low_complexity_counts();
+        if examined > 0 {
+            self.kmer_windows_examined.fetch_add(examined, Ordering::Relaxed);
+            self.low_complexity_kmers_removed.fetch_add(removed, Ordering::Relaxed);
+        }
 
         // Return the processed signature (don't store it yet)
         Ok(protein_sig)
@@ -1759,6 +1836,9 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::index::ProteomeIndex;
+    // Private to the module; needed to forge a pre-versioning index in
+    // test_unversioned_index_reads_through_legacy_metadata_layout.
+    use super::{LegacyProteomeIndexMetadata, ProteomeIndexMetadata, KMERSEEK_VERSION_KEY};
     use crate::sketch::ProteinSketch;
     use crate::tests::test_fixtures::{
         TEST_FASTA_CONTENT, TEST_FASTA_GZ, TEST_FASTA_ZST, TEST_PROTEIN,
@@ -2168,6 +2248,65 @@ mod tests {
         Ok(())
     }
 
+    // Residues 26-55 of human FKBP8 (UniProt Q14318): a genuine 11-residue
+    // poly-glutamate tract, real low-complexity sequence rather than an
+    // invented motif.
+    const FKBP8_POLY_E: &str = "VLDGVEDAEGEEEEEEEEEEEDDLSELPPL";
+
+    /// The index-level counts aggregate across every stored signature; main.rs
+    /// prints them after indexing.
+    #[test]
+    fn test_index_low_complexity_counts_aggregate_across_signatures() -> Result<()> {
+        let dir = tempdir()?;
+
+        // Two distinct sequences -- storing the same one twice would collapse to a
+        // single md5 key and prove nothing about aggregation.
+        // TEST_PROTEIN: 17 windows, 1 removed ("IMALG", all-hydrophobic).
+        // FKBP8_POLY_E: 26 windows, 9 removed (7 raw "EEEEE" + 2 encoded "ppppp").
+        let mut index = ProteomeIndex::new(dir.path().join("counts.db"), 5, 1, "hp", false)?;
+        index.set_remove_low_complexity(true);
+        for (name, seq) in [("p1", TEST_PROTEIN), ("p2", FKBP8_POLY_E)] {
+            let sig = index.create_protein_signature(seq, name)?;
+            index.store_signatures(vec![sig])?;
+        }
+        assert_eq!(index.get_signatures().len(), 2, "both sequences should be stored");
+        assert_eq!(index.low_complexity_counts(), (43, 10));
+
+        // With removal off nothing walks windows itself, so both stay zero.
+        let index_off = ProteomeIndex::new(dir.path().join("counts_off.db"), 5, 1, "hp", false)?;
+        let sig = index_off.create_protein_signature(TEST_PROTEIN, "p1")?;
+        index_off.store_signatures(vec![sig])?;
+        assert_eq!(index_off.low_complexity_counts(), (0, 0));
+
+        Ok(())
+    }
+
+    /// The builder must carry the flag through to the constructed index.
+    #[test]
+    fn test_builder_sets_remove_low_complexity() -> Result<()> {
+        let dir = tempdir()?;
+
+        let on = ProteomeIndex::builder()
+            .path(dir.path().join("builder_on.db"))
+            .ksize(5)
+            .scaled(1)
+            .moltype("hp")
+            .remove_low_complexity(true)
+            .build()?;
+        assert!(on.remove_low_complexity());
+
+        // Defaults to false when the builder method is not called.
+        let off = ProteomeIndex::builder()
+            .path(dir.path().join("builder_off.db"))
+            .ksize(5)
+            .scaled(1)
+            .moltype("hp")
+            .build()?;
+        assert!(!off.remove_low_complexity());
+
+        Ok(())
+    }
+
     /// The setting must survive save_state -> open_for_search, since search
     /// relies on it to build query sketches the same way the targets were built.
     #[test]
@@ -2199,7 +2338,7 @@ mod tests {
     /// kept every k-mer by definition, so a missing key must read as false rather
     /// than erroring out.
     #[test]
-    fn test_missing_remove_low_complexity_key_reads_as_false() -> Result<()> {
+    fn test_unversioned_index_reads_through_legacy_metadata_layout() -> Result<()> {
         let dir = tempdir()?;
         let db_path = dir.path().join("legacy.db");
         {
@@ -2209,15 +2348,55 @@ mod tests {
             index.save_state()?;
         }
 
-        // Simulate a pre-flag index by deleting the key save_state wrote.
+        // Rewrite the index as a pre-versioning one: metadata in the old 8-field
+        // layout, and no kmerseek_version key.
         {
             use rocksdb::{Options, DB};
             let db = DB::open(&Options::default(), &db_path)?;
-            db.delete(b"remove_low_complexity")?;
+            let current: ProteomeIndexMetadata =
+                bincode::deserialize(&db.get(b"index_metadata")?.unwrap())?;
+            let legacy = LegacyProteomeIndexMetadata {
+                total_signatures: current.total_signatures,
+                chunk_count: current.chunk_count,
+                combined_mins: current.combined_mins,
+                combined_abunds: current.combined_abunds,
+                moltype: current.moltype,
+                ksize: current.ksize,
+                scaled: current.scaled,
+                store_raw_sequences: current.store_raw_sequences,
+            };
+            db.put(b"index_metadata", bincode::serialize(&legacy)?)?;
+            db.delete(KMERSEEK_VERSION_KEY)?;
         }
 
+        // The legacy layout still loads, and defaults the flag to false.
         let reopened = ProteomeIndex::open_for_search(&db_path)?;
         assert!(!reopened.remove_low_complexity());
+        assert_eq!(reopened.ksize(), 5);
+        assert_eq!(reopened.moltype(), "hp");
+
+        Ok(())
+    }
+
+    /// Indexes written now carry the kmerseek version, both as provenance and as
+    /// the marker for the current metadata layout.
+    #[test]
+    fn test_save_state_stamps_kmerseek_version() -> Result<()> {
+        use rocksdb::{Options, DB};
+        let dir = tempdir()?;
+        let db_path = dir.path().join("versioned.db");
+        {
+            let index = ProteomeIndex::new(&db_path, 5, 1, "hp", true)?;
+            let sig = index.create_protein_signature(TEST_PROTEIN, "p")?;
+            index.store_signatures(vec![sig])?;
+            index.save_state()?;
+        }
+
+        let db = DB::open(&Options::default(), &db_path)?;
+        assert_eq!(
+            ProteomeIndex::read_kmerseek_version(&db)?,
+            Some(env!("CARGO_PKG_VERSION").to_string())
+        );
 
         Ok(())
     }

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
-use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
+use std::collections::{BTreeMap, BinaryHeap, HashMap};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/rust/kmer.rs
+++ b/src/rust/kmer.rs
@@ -35,9 +35,11 @@ impl AsRef<str> for Kmer {
     }
 }
 
-/// True if every byte in a k-mer is the same, the lowest-complexity case for
-/// any alphabet: a raw amino-acid homopolymer (e.g. `"AAAAA"`), or a
-/// homopolymer run under a reduced alphabet like HP (e.g. `"hhhhh"`).
+/// True if every byte in a k-mer is the same.
+///
+/// This is the lowest-complexity case for any alphabet: a raw amino-acid
+/// homopolymer such as `"AAAAA"`, or a homopolymer run under a reduced
+/// alphabet like HP, such as `"hhhhh"`. Empty input is not a homopolymer.
 ///
 /// Case-insensitive, so it accepts both lowercase and uppercase encodings.
 pub fn is_homopolymer_kmer(kmer: &[u8]) -> bool {

--- a/src/rust/kmer.rs
+++ b/src/rust/kmer.rs
@@ -34,3 +34,41 @@ impl AsRef<str> for Kmer {
         &self.inner
     }
 }
+
+/// True if every byte in a k-mer is the same, the lowest-complexity case for
+/// any alphabet: a raw amino-acid homopolymer (e.g. `"AAAAA"`), or a
+/// homopolymer run under a reduced alphabet like HP (e.g. `"hhhhh"`).
+///
+/// Case-insensitive, so it accepts both lowercase and uppercase encodings.
+pub fn is_homopolymer_kmer(kmer: &[u8]) -> bool {
+    match kmer.split_first() {
+        None => false,
+        Some((&first, rest)) => rest.iter().all(|b| b.eq_ignore_ascii_case(&first)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_homopolymer_kmer_detects_runs() {
+        assert!(is_homopolymer_kmer(b"AAAAA"));
+        assert!(is_homopolymer_kmer(b"hhhhh"));
+        assert!(is_homopolymer_kmer(b"ppppp"));
+        // Case-insensitive: matches the uppercase encoding used for custom HP alphabets.
+        assert!(is_homopolymer_kmer(b"HHHHH"));
+        // Mixed case of the same residue/class is still a homopolymer run.
+        assert!(is_homopolymer_kmer(b"aAaA"));
+        // A single-residue k-mer is trivially a homopolymer run.
+        assert!(is_homopolymer_kmer(b"A"));
+    }
+
+    #[test]
+    fn is_homopolymer_kmer_rejects_mixed_kmers() {
+        assert!(!is_homopolymer_kmer(b"MKTAY"));
+        assert!(!is_homopolymer_kmer(b"hhphh"));
+        assert!(!is_homopolymer_kmer(b"ph"));
+        assert!(!is_homopolymer_kmer(b""));
+    }
+}

--- a/src/rust/main.rs
+++ b/src/rust/main.rs
@@ -336,6 +336,10 @@ fn main() -> IndexResult<()> {
             // that contain low-complexity regions.
             let remove_low_complexity = searcher.index().remove_low_complexity();
             eprintln!("  Remove low-complexity k-mers: {} (from index)", remove_low_complexity);
+            eprintln!(
+                "  Index built by kmerseek: {}",
+                searcher.index().kmerseek_version().unwrap_or("unknown (pre-versioning index)")
+            );
 
             // Perform search - use optimized all-vs-all method if query == target
             let search_results = if is_all_vs_all {

--- a/src/rust/main.rs
+++ b/src/rust/main.rs
@@ -92,6 +92,15 @@ enum Commands {
         #[arg(long, default_value = "0.05")]
         max_pvalue: f64,
 
+        /// Remove low-complexity (homopolymer) k-mers from query sketches.
+        /// Omit this to follow whatever the target index was built with, which is
+        /// almost always what you want. Pass it (or `--remove-low-complexity
+        /// false`) only to override deliberately; a value that disagrees with the
+        /// index is reported as a warning, because the two sides must match for
+        /// containment to be comparable.
+        #[arg(long, value_name = "BOOL", num_args = 0..=1, default_missing_value = "true")]
+        remove_low_complexity: Option<bool>,
+
         /// Whether to output detailed match info to stderr (always extracts k-mers)
         #[arg(long, default_value = "false")]
         verbose: bool,
@@ -273,6 +282,7 @@ fn main() -> IndexResult<()> {
             threshold,
             min_shared_kmers,
             max_pvalue,
+            remove_low_complexity: remove_low_complexity_arg,
             verbose,
             query_is_index,
             batch_size,
@@ -334,8 +344,29 @@ fn main() -> IndexResult<()> {
             // those k-mers match nothing yet still count toward the query cardinality,
             // deflating containment (intersection / query_size) for exactly the queries
             // that contain low-complexity regions.
-            let remove_low_complexity = searcher.index().remove_low_complexity();
-            eprintln!("  Remove low-complexity k-mers: {} (from index)", remove_low_complexity);
+            let index_removed = searcher.index().remove_low_complexity();
+            let remove_low_complexity = remove_low_complexity_arg.unwrap_or(index_removed);
+
+            eprintln!(
+                "  Index: low-complexity k-mers were {} when it was built",
+                if index_removed { "REMOVED" } else { "KEPT" }
+            );
+            eprintln!(
+                "  This search: low-complexity k-mers are {} from query sketches ({})",
+                if remove_low_complexity { "REMOVED" } else { "KEPT" },
+                if remove_low_complexity_arg.is_some() {
+                    "--remove-low-complexity"
+                } else {
+                    "matching the index"
+                }
+            );
+            if remove_low_complexity != index_removed {
+                eprintln!(
+                    "  WARNING: this disagrees with the index. Containment is \
+                     intersection / query_size, so k-mers present on only one side \
+                     still count toward the denominator and skew scores."
+                );
+            }
             eprintln!(
                 "  Index built by kmerseek: {}",
                 searcher.index().kmerseek_version().unwrap_or("unknown (pre-versioning index)")
@@ -463,8 +494,11 @@ fn main() -> IndexResult<()> {
                         for result in results {
                             *match_count += 1;
                             for region in &result.matched_regions {
-                                let csv_row =
-                                    SearchResultCsv::from_result_and_region(result, region);
+                                let csv_row = SearchResultCsv::from_result_and_region(
+                                    result,
+                                    region,
+                                    remove_low_complexity,
+                                );
                                 writer.serialize(&csv_row)?;
                                 *row_count += 1;
                             }
@@ -546,7 +580,11 @@ fn main() -> IndexResult<()> {
 
                 for result in &filtered_results {
                     for region in &result.matched_regions {
-                        let csv_row = SearchResultCsv::from_result_and_region(result, region);
+                        let csv_row = SearchResultCsv::from_result_and_region(
+                            result,
+                            region,
+                            remove_low_complexity,
+                        );
                         writer.serialize(&csv_row)?;
                     }
                 }
@@ -557,7 +595,11 @@ fn main() -> IndexResult<()> {
 
                 for result in &filtered_results {
                     for region in &result.matched_regions {
-                        let csv_row = SearchResultCsv::from_result_and_region(result, region);
+                        let csv_row = SearchResultCsv::from_result_and_region(
+                            result,
+                            region,
+                            remove_low_complexity,
+                        );
                         writer.serialize(&csv_row)?;
                     }
                 }

--- a/src/rust/main.rs
+++ b/src/rust/main.rs
@@ -45,6 +45,14 @@ enum Commands {
         /// moltype, ksize, occurrences, n_kmers.
         #[arg(long, value_name = "PATH")]
         kmer_stats_out: Option<PathBuf>,
+
+        /// Remove low-complexity (homopolymer) k-mers from the index: raw
+        /// amino-acid runs (e.g. "AAAAA") for any encoding, plus all-h or all-p
+        /// runs for HP-family encodings (hp, hp_lehninger, hp_thomas_dill, etc.).
+        /// The setting is stored in the index and reused automatically at search
+        /// time, so you do not repeat it when searching.
+        #[arg(long, default_value = "false")]
+        remove_low_complexity: bool,
     },
     /// Search query sequences against a protein database
     Search {
@@ -162,6 +170,7 @@ fn main() -> IndexResult<()> {
             shuffled_seed,
             progress_interval,
             kmer_stats_out,
+            remove_low_complexity,
         } => {
             eprintln!("Indexing FASTA file: {}", input.display());
 
@@ -190,13 +199,16 @@ fn main() -> IndexResult<()> {
                     input.file_name().and_then(|name| name.to_str()).unwrap_or("unknown");
 
                 // Create a temporary index to generate the filename
-                let temp_index = ProteomeIndex::new_with_auto_filename(
+                let mut temp_index = ProteomeIndex::new_with_auto_filename(
                     &input,
                     ksize,
                     scaled,
                     &effective_moltype,
                     true, // Always store raw sequences
                 )?;
+                // Must match the real index, so the generated name carries the
+                // suffix and can't collide with a build that kept these k-mers.
+                temp_index.set_remove_low_complexity(remove_low_complexity);
 
                 let generated_filename = temp_index.generate_filename(base_name);
                 let output_path = input
@@ -212,20 +224,34 @@ fn main() -> IndexResult<()> {
             eprintln!("Scaled: {}", scaled);
             eprintln!("Encoding: {}", effective_moltype);
             eprintln!("Progress interval: {}", progress_interval);
+            eprintln!("Remove low-complexity k-mers: {}", remove_low_complexity);
             eprintln!("-------\n");
 
             // Create the index
-            let index = ProteomeIndex::new(
+            let mut index = ProteomeIndex::new(
                 &output_path,
                 ksize,
                 scaled,
                 &effective_moltype,
                 true, // Always store raw sequences
             )?;
+            index.set_remove_low_complexity(remove_low_complexity);
 
             // Process the FASTA file
             eprintln!("Processing FASTA file...");
             index.process_fasta(&input, progress_interval, 1000)?;
+
+            // Report what removal actually did, so its effect is visible without
+            // having to rebuild and diff two indexes.
+            if remove_low_complexity {
+                let (examined, skipped) = index.low_complexity_counts();
+                let percent =
+                    if examined == 0 { 0.0 } else { 100.0 * skipped as f64 / examined as f64 };
+                eprintln!(
+                    "Removed {} of {} k-mer windows as low-complexity ({:.2}%)",
+                    skipped, examined, percent
+                );
+            }
 
             // Enable compactions for better read performance
             eprintln!("Optimizing database for read operations...");
@@ -303,6 +329,14 @@ fn main() -> IndexResult<()> {
             eprintln!("Loading target database...");
             let mut searcher = ProteinSearcher::load(&target)?;
 
+            // Build query sketches the same way the target index was built.
+            // WHY: if the index dropped low-complexity k-mers but queries keep them,
+            // those k-mers match nothing yet still count toward the query cardinality,
+            // deflating containment (intersection / query_size) for exactly the queries
+            // that contain low-complexity regions.
+            let remove_low_complexity = searcher.index().remove_low_complexity();
+            eprintln!("  Remove low-complexity k-mers: {} (from index)", remove_low_complexity);
+
             // Perform search - use optimized all-vs-all method if query == target
             let search_results = if is_all_vs_all {
                 // Use optimized all-vs-all search that avoids cloning signatures
@@ -361,6 +395,7 @@ fn main() -> IndexResult<()> {
                             final_scaled,
                             final_encoding.into(),
                         )?;
+                        sig.set_remove_low_complexity(remove_low_complexity);
                         sig.add_protein(&sequence, true)?;
                         for min in sig.signature().minhash.mins() {
                             *qfreqs.entry(min).or_insert(0) += 1;
@@ -445,6 +480,7 @@ fn main() -> IndexResult<()> {
 
                     let mut query_sig =
                         ProteinSketch::new(name, final_ksize, final_scaled, final_encoding.into())?;
+                    query_sig.set_remove_low_complexity(remove_low_complexity);
                     query_sig.add_protein(&sequence, true)?;
                     batch.push(query_sig);
 

--- a/src/rust/search.rs
+++ b/src/rust/search.rs
@@ -63,6 +63,10 @@ pub struct SearchResultCsv {
     pub ksize: u32,
     pub scaled: u32,
     pub moltype: String,
+    /// Whether low-complexity (homopolymer) k-mers were removed from both the
+    /// index and the query sketches for this search. Recorded per row, like
+    /// ksize/scaled/moltype, so a results file is self-describing.
+    pub remove_low_complexity: bool,
     pub jaccard: f64,
     pub max_containment: f64,
     pub average_abund: f64,
@@ -99,7 +103,11 @@ impl SearchResultCsv {
     /// similarity metrics with a specific matched region to create one CSV row. Each SearchResult
     /// will produce multiple CSV rows (one per matched region), with all similarity metrics
     /// repeated for each region.
-    pub fn from_result_and_region(result: &SearchResult, region: &MatchedRegion) -> Self {
+    pub fn from_result_and_region(
+        result: &SearchResult,
+        region: &MatchedRegion,
+        remove_low_complexity: bool,
+    ) -> Self {
         Self {
             query_name: result.query_name.clone(),
             query_md5: result.query_md5.clone(),
@@ -110,6 +118,7 @@ impl SearchResultCsv {
             ksize: result.ksize,
             scaled: result.scaled,
             moltype: result.moltype.clone(),
+            remove_low_complexity,
             jaccard: result.jaccard,
             max_containment: result.max_containment,
             average_abund: result.average_abund,
@@ -1287,7 +1296,7 @@ mod tests {
             matched_regions: vec![],
         };
 
-        let row = SearchResultCsv::from_result_and_region(&result, &region);
+        let row = SearchResultCsv::from_result_and_region(&result, &region, false);
 
         // Fields carried from the SearchResult.
         assert_eq!(row.query_name, "query1");

--- a/src/rust/sketch.rs
+++ b/src/rust/sketch.rs
@@ -742,6 +742,51 @@ mod tests {
         assert_eq!(on.kmer_positions().len(), 19);
     }
 
+    /// Custom `hp_*` alphabets take a separate encode-and-check path from the
+    /// sourmash built-in `hp` (they pre-encode to uppercase H/P via their own
+    /// table), so removal has to be exercised there too.
+    #[test]
+    fn test_remove_low_complexity_custom_hp_alphabet() {
+        use crate::tests::test_fixtures::TEST_PROTEIN;
+
+        // "IMALG" (position 10 of TEST_PROTEIN) is all-hydrophobic under the
+        // Lehninger partition, which places G in the h class. It is not a raw
+        // amino-acid homopolymer, so only the HP-encoded check can catch it --
+        // exactly the branch this test covers.
+        let mut off = ProteinSketch::new("off", 5, 1, "hp_lehninger").unwrap();
+        off.add_protein(TEST_PROTEIN, false).unwrap();
+        assert_eq!(off.kmer_positions().len(), 14);
+        assert_eq!(off.low_complexity_counts(), (0, 0), "counters stay 0 when removal is off");
+
+        let mut on = ProteinSketch::new("on", 5, 1, "hp_lehninger").unwrap();
+        on.set_remove_low_complexity(true);
+        on.add_protein(TEST_PROTEIN, false).unwrap();
+        assert_eq!(on.kmer_positions().len(), 13);
+
+        // 21 residues at k=5 gives 17 windows; exactly one ("IMALG") is removed.
+        assert_eq!(on.low_complexity_counts(), (17, 1));
+    }
+
+    /// Both checks contribute on the same sequence: the raw check fires first and
+    /// short-circuits, so a window only reaches the encoded check when it is not
+    /// already a raw homopolymer.
+    #[test]
+    fn test_remove_low_complexity_counts_raw_and_encoded_together() {
+        let mut on = ProteinSketch::new("on", 5, 1, "hp_lehninger").unwrap();
+        on.set_remove_low_complexity(true);
+        on.add_protein(FKBP8_POLY_E, false).unwrap();
+
+        // FKBP8_POLY_E is 30 residues -> 26 windows at k=5. Its HP (Lehninger)
+        // encoding is:
+        //   VLDGVEDAEGEEEEEEEEEEEDDLSELPPL
+        //   hhphhpphphppppppppppppphpphhhh
+        // The 11-residue E tract yields 7 fully-inside "EEEEE" windows, caught by
+        // the raw check. Two further windows ("EEEED", "EEEDD") are not raw
+        // homopolymers but still encode to "ppppp", so only the encoded check
+        // catches them. 7 + 2 = 9.
+        assert_eq!(on.low_complexity_counts(), (26, 9));
+    }
+
     #[test]
     fn test_efficient_data_roundtrip() {
         let s = protein_sketch();

--- a/src/rust/sketch.rs
+++ b/src/rust/sketch.rs
@@ -377,11 +377,11 @@ impl ProteinSketch {
         // like "LIVMA"). This means hashing one k-mer at a time instead of
         // delegating to sourmash's black-box `add_protein`, which windows and
         // inserts unconditionally. `remove_low_complexity` defaults to false,
-        // preserving the original keep-everything behavior below.
+        // and the branch below keeps every k-mer.
         if self.remove_low_complexity {
-            // Hoisted out of the loop: both are loop-invariant, and resolving the
-            // encoding function per window showed up as pure overhead.
-            let table = custom_hp.as_ref().map(|alpha| alpha.table());
+            // Hoisted: both are loop-invariant, so resolving them per window would
+            // be pure overhead.
+            let table = custom_hp.as_ref().map(HpAlphabet::table);
             let encoding_fn = get_encoding_fn_from_moltype(&moltype_str)?;
             // Reused across windows so the custom-HP path allocates once, not once
             // per k-mer.

--- a/src/rust/sketch.rs
+++ b/src/rust/sketch.rs
@@ -379,6 +379,14 @@ impl ProteinSketch {
         // inserts unconditionally. `remove_low_complexity` defaults to false,
         // preserving the original keep-everything behavior below.
         if self.remove_low_complexity {
+            // Hoisted out of the loop: both are loop-invariant, and resolving the
+            // encoding function per window showed up as pure overhead.
+            let table = custom_hp.as_ref().map(|alpha| alpha.table());
+            let encoding_fn = get_encoding_fn_from_moltype(&moltype_str)?;
+            // Reused across windows so the custom-HP path allocates once, not once
+            // per k-mer.
+            let mut encoded: Vec<u8> = Vec::with_capacity(ksize);
+
             self.kmer_windows_examined = 0;
             self.low_complexity_kmers_removed = 0;
             for i in 0..sequence.len().saturating_sub(ksize - 1) {
@@ -388,35 +396,32 @@ impl ProteinSketch {
                     self.low_complexity_kmers_removed += 1;
                     continue;
                 }
-                let hashval = if let Some(ref alpha) = custom_hp {
-                    let table = alpha.table();
-                    let encoded: Vec<u8> = kmer
-                        .bytes()
-                        .map(|b| {
-                            table
-                                .get(&b.to_ascii_uppercase())
-                                .copied()
-                                .unwrap_or(b)
-                                .to_ascii_uppercase()
-                        })
-                        .collect();
+                let hashval = if let Some(table) = table {
+                    encoded.clear();
+                    encoded.extend(kmer.bytes().map(|b| {
+                        table
+                            .get(&b.to_ascii_uppercase())
+                            .copied()
+                            .unwrap_or(b)
+                            .to_ascii_uppercase()
+                    }));
                     if is_homopolymer_kmer(&encoded) {
                         self.low_complexity_kmers_removed += 1;
                         continue;
                     }
                     _hash_murmur(&encoded, SEED)
                 } else {
-                    let encoding_fn = get_encoding_fn_from_moltype(&moltype_str)?;
-                    match encode_with_fn(kmer, encoding_fn) {
-                        Ok(encoded_kmer) => {
-                            if is_hp_moltype && is_homopolymer_kmer(encoded_kmer.as_bytes()) {
-                                self.low_complexity_kmers_removed += 1;
-                                continue;
-                            }
-                            _hash_murmur(encoded_kmer.as_bytes(), SEED)
-                        }
-                        Err(_) => continue,
+                    // WHY still encode_with_fn here rather than mapping bytes: the
+                    // position-tracking loop below hashes its String's bytes, and for
+                    // any non-ASCII byte `char`-conversion re-encodes as multi-byte
+                    // UTF-8. Going through the same function keeps both loops hashing
+                    // identical bytes.
+                    let encoded_kmer = encode_with_fn(kmer, encoding_fn)?;
+                    if is_hp_moltype && is_homopolymer_kmer(encoded_kmer.as_bytes()) {
+                        self.low_complexity_kmers_removed += 1;
+                        continue;
                     }
+                    _hash_murmur(encoded_kmer.as_bytes(), SEED)
                 };
                 self.signature.minhash.add_hash(hashval);
             }

--- a/src/rust/sketch.rs
+++ b/src/rust/sketch.rs
@@ -21,6 +21,15 @@ pub struct ProteinSketch {
     kmer_positions: HashMap<u64, Vec<usize>>,
     // Efficient storage data (optional, for performance)
     efficient_data: Option<ProteinSketchStore>,
+    // Whether add_protein() should drop low-complexity (homopolymer) k-mers.
+    // Defaults to false (legacy behavior); not persisted, since it only affects
+    // insertion, not the sketch that results from it.
+    remove_low_complexity: bool,
+    // Counts from the most recent add_protein() with removal on: k-mer windows
+    // examined, and windows removed as low-complexity. Both stay 0 when off.
+    // Not persisted; used only for index-time reporting.
+    kmer_windows_examined: usize,
+    low_complexity_kmers_removed: usize,
 }
 
 // Custom serialization for ProteinSketch
@@ -130,6 +139,9 @@ impl<'de> Deserialize<'de> for ProteinSketch {
                     scaled,
                     kmer_positions,
                     efficient_data: None,
+                    remove_low_complexity: false,
+                    kmer_windows_examined: 0,
+                    low_complexity_kmers_removed: 0,
                 })
             }
         }
@@ -171,7 +183,23 @@ impl ProteinSketch {
             scaled,
             kmer_positions: HashMap::new(),
             efficient_data: None,
+            remove_low_complexity: false,
+            kmer_windows_examined: 0,
+            low_complexity_kmers_removed: 0,
         })
+    }
+
+    /// Enable or disable dropping low-complexity (homopolymer) k-mers during
+    /// `add_protein`. Defaults to `false`.
+    pub fn set_remove_low_complexity(&mut self, remove_low_complexity: bool) {
+        self.remove_low_complexity = remove_low_complexity;
+    }
+
+    /// K-mer windows examined by the most recent `add_protein` with removal on,
+    /// and how many of those were removed as low-complexity. Both are 0 when
+    /// removal is off, since that path never walks windows itself.
+    pub fn low_complexity_counts(&self) -> (usize, usize) {
+        (self.kmer_windows_examined, self.low_complexity_kmers_removed)
     }
 
     /// Create a ProteinSketch from a protein sequence
@@ -204,6 +232,9 @@ impl ProteinSketch {
             scaled,
             kmer_positions,
             efficient_data: None,
+            remove_low_complexity: false,
+            kmer_windows_examined: 0,
+            low_complexity_kmers_removed: 0,
         }
     }
 
@@ -248,6 +279,9 @@ impl ProteinSketch {
             scaled,
             kmer_positions: data.kmer_positions.clone(),
             efficient_data: Some(data),
+            remove_low_complexity: false,
+            kmer_windows_examined: 0,
+            low_complexity_kmers_removed: 0,
         })
     }
 
@@ -327,12 +361,66 @@ impl ProteinSketch {
     pub fn add_protein(&mut self, sequence: &str, store_sequences: bool) -> anyhow::Result<()> {
         use crate::encoding::{encode_by_moltype, encode_with_fn, get_encoding_fn_from_moltype};
         use crate::hp_alphabets::HpAlphabet;
+        use crate::kmer::is_homopolymer_kmer;
         use sourmash::_hash_murmur;
 
         let moltype_str = self.moltype.to_string();
         let custom_hp = HpAlphabet::from_moltype(&moltype_str);
+        let ksize = self.protein_ksize as usize;
+        let is_hp_moltype = custom_hp.is_some() || moltype_str == "hp";
 
-        if let Some(ref alpha) = custom_hp {
+        // WHY: low-complexity k-mers carry little discriminative signal, so when
+        // opted in, two independent homopolymer checks run per k-mer before
+        // insertion: the raw amino-acid sequence (e.g. "AAAAA", any moltype)
+        // and, for HP-family moltypes, the HP-encoded window (e.g. "hhhhh",
+        // which can also arise from a run of *different* hydrophobic residues
+        // like "LIVMA"). This means hashing one k-mer at a time instead of
+        // delegating to sourmash's black-box `add_protein`, which windows and
+        // inserts unconditionally. `remove_low_complexity` defaults to false,
+        // preserving the original keep-everything behavior below.
+        if self.remove_low_complexity {
+            self.kmer_windows_examined = 0;
+            self.low_complexity_kmers_removed = 0;
+            for i in 0..sequence.len().saturating_sub(ksize - 1) {
+                let kmer = &sequence[i..i + ksize];
+                self.kmer_windows_examined += 1;
+                if is_homopolymer_kmer(kmer.as_bytes()) {
+                    self.low_complexity_kmers_removed += 1;
+                    continue;
+                }
+                let hashval = if let Some(ref alpha) = custom_hp {
+                    let table = alpha.table();
+                    let encoded: Vec<u8> = kmer
+                        .bytes()
+                        .map(|b| {
+                            table
+                                .get(&b.to_ascii_uppercase())
+                                .copied()
+                                .unwrap_or(b)
+                                .to_ascii_uppercase()
+                        })
+                        .collect();
+                    if is_homopolymer_kmer(&encoded) {
+                        self.low_complexity_kmers_removed += 1;
+                        continue;
+                    }
+                    _hash_murmur(&encoded, SEED)
+                } else {
+                    let encoding_fn = get_encoding_fn_from_moltype(&moltype_str)?;
+                    match encode_with_fn(kmer, encoding_fn) {
+                        Ok(encoded_kmer) => {
+                            if is_hp_moltype && is_homopolymer_kmer(encoded_kmer.as_bytes()) {
+                                self.low_complexity_kmers_removed += 1;
+                                continue;
+                            }
+                            _hash_murmur(encoded_kmer.as_bytes(), SEED)
+                        }
+                        Err(_) => continue,
+                    }
+                };
+                self.signature.minhash.add_hash(hashval);
+            }
+        } else if let Some(ref alpha) = custom_hp {
             // Pre-encode with our custom HP table so sourmash hashes h/p bytes via
             // Murmur64Protein (identity). Unknown bytes pass through unchanged.
             let table = alpha.table();
@@ -349,7 +437,6 @@ impl ProteinSketch {
             self.signature.minhash.mins().iter().fold(0u64, |acc, &min| acc.wrapping_add(min));
         self.signature.md5sum = format!("{:x}", md5sum);
 
-        let ksize = self.protein_ksize as usize;
         let hashvals: HashSet<u64> = self.signature().minhash.mins().iter().copied().collect();
 
         for i in 0..sequence.len().saturating_sub(ksize - 1) {
@@ -602,6 +689,57 @@ mod tests {
     fn test_non_protein_moltype_stores_encoded_sequence() {
         let s = ProteinSketch::from_protein_sequence("p", SEQ, 5, 1, "hp").unwrap();
         assert_eq!(s.get_moltype_sequence(), Some(SEQ_HP_ENCODED));
+    }
+
+    #[test]
+    fn test_remove_low_complexity_hp_kmers_toggle() {
+        use crate::tests::test_fixtures::TEST_PROTEIN;
+
+        // TEST_PROTEIN = "PLANTANDANIMALGENQMES"; the window at position 10,
+        // "IMALG", is all-hydrophobic ("hhhhh") under the HP (Lehninger)
+        // alphabet — the low-complexity case this targets.
+        const IMALG_HASH: u64 = 8541583772724823208;
+
+        // Default (off): low-complexity k-mers are kept, matching legacy behavior.
+        let mut off = ProteinSketch::new("off", 5, 1, "hp").unwrap();
+        off.add_protein(TEST_PROTEIN, false).unwrap();
+        assert_eq!(off.kmer_positions().len(), 14);
+        assert!(off.kmer_positions().contains_key(&IMALG_HASH));
+
+        // Opted in: the all-hydrophobic "IMALG" k-mer is dropped.
+        let mut on = ProteinSketch::new("on", 5, 1, "hp").unwrap();
+        on.set_remove_low_complexity(true);
+        on.add_protein(TEST_PROTEIN, false).unwrap();
+        assert_eq!(on.kmer_positions().len(), 13);
+        assert!(!on.kmer_positions().contains_key(&IMALG_HASH));
+    }
+
+    // Residues 26-55 of human FKBP8 (UniProt Q14318), which contains a genuine
+    // 11-residue poly-glutamate (E) tract — a real low-complexity region, not
+    // an invented motif.
+    const FKBP8_POLY_E: &str = "VLDGVEDAEGEEEEEEEEEEEDDLSELPPL";
+
+    #[test]
+    fn test_remove_low_complexity_raw_amino_acid_homopolymer() {
+        // Hash of "EEEEE" under the identity (protein) encoding.
+        const POLY_E_HASH: u64 = 11331501307295692494;
+
+        // Default (off): the raw poly-E homopolymer k-mer is kept, matching
+        // legacy behavior. The 7 overlapping "EEEEE" windows (positions 10-16
+        // within FKBP8_POLY_E) collapse to a single hash entry with 7 positions.
+        let mut off = ProteinSketch::new("off", 5, 1, "protein").unwrap();
+        off.add_protein(FKBP8_POLY_E, false).unwrap();
+        assert!(off.kmer_positions().contains_key(&POLY_E_HASH));
+        assert_eq!(off.kmer_positions()[&POLY_E_HASH].len(), 7);
+        assert_eq!(off.kmer_positions().len(), 20);
+
+        // Opted in: the raw poly-E k-mer is dropped, even though this is
+        // "protein" moltype (no HP encoding involved at all).
+        let mut on = ProteinSketch::new("on", 5, 1, "protein").unwrap();
+        on.set_remove_low_complexity(true);
+        on.add_protein(FKBP8_POLY_E, false).unwrap();
+        assert!(!on.kmer_positions().contains_key(&POLY_E_HASH));
+        assert_eq!(on.kmer_positions().len(), 19);
     }
 
     #[test]

--- a/src/rust/tests/test_cli.rs
+++ b/src/rust/tests/test_cli.rs
@@ -109,6 +109,86 @@ fn test_cli_index_different_encodings() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
+/// Low-complexity removal must round-trip: `index --remove-low-complexity`
+/// persists the setting, and `search` picks it up from the index without the
+/// user restating it. A mismatch would silently skew containment, so this
+/// asserts on the reported value rather than just on exit status.
+#[test]
+fn test_cli_remove_low_complexity_round_trips_to_search() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temp_dir = tempdir()?;
+
+    for (flag, expected) in [(true, "true"), (false, "false")] {
+        let index_path = temp_dir.path().join(format!("lc_{}.db", flag));
+
+        let mut index_cmd = Command::cargo_bin("kmerseek")?;
+        index_cmd.args([
+            "index",
+            "--input",
+            TEST_FASTA_GZ,
+            "--output",
+            index_path.to_str().unwrap(),
+            "--ksize",
+            "12",
+            "--encoding",
+            "hp",
+        ]);
+        if flag {
+            index_cmd.arg("--remove-low-complexity");
+        }
+        index_cmd
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Indexing completed successfully!"));
+
+        // Search must recover the setting from the index, with no flag passed here.
+        let mut search_cmd = Command::cargo_bin("kmerseek")?;
+        search_cmd.args([
+            "search",
+            "--query",
+            TEST_CED9_FASTA,
+            "--target",
+            index_path.to_str().unwrap(),
+            "--ksize",
+            "12",
+            "--encoding",
+            "hp",
+        ]);
+        search_cmd.assert().success().stderr(predicate::str::contains(format!(
+            "Remove low-complexity k-mers: {} (from index)",
+            expected
+        )));
+    }
+
+    Ok(())
+}
+
+/// Auto-generated names must differ with and without removal, or indexing the
+/// same FASTA both ways would silently clobber the first database.
+#[test]
+fn test_cli_remove_low_complexity_auto_filename_does_not_collide(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    let fasta = temp_dir.path().join("ced9.fasta");
+    std::fs::copy(TEST_CED9_FASTA, &fasta)?;
+
+    for flag in [false, true] {
+        let mut cmd = Command::cargo_bin("kmerseek")?;
+        cmd.args(["index", "--input", fasta.to_str().unwrap(), "--ksize", "8", "--encoding", "hp"]);
+        if flag {
+            cmd.arg("--remove-low-complexity");
+        }
+        cmd.assert().success();
+    }
+
+    let kept_all = temp_dir.path().join("ced9.fasta.hp.k8.scaled1.kmerseek.rocksdb");
+    let removed = temp_dir.path().join("ced9.fasta.hp.k8.scaled1.nolowcomplexity.kmerseek.rocksdb");
+    assert!(kept_all.exists(), "index keeping every k-mer should keep its historical name");
+    assert!(removed.exists(), "index with removal should get its own name");
+
+    Ok(())
+}
+
 #[test]
 fn test_cli_index_nonexistent_file() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempdir()?;

--- a/src/rust/tests/test_cli.rs
+++ b/src/rust/tests/test_cli.rs
@@ -154,10 +154,127 @@ fn test_cli_remove_low_complexity_round_trips_to_search() -> Result<(), Box<dyn 
             "--encoding",
             "hp",
         ]);
-        search_cmd.assert().success().stderr(predicate::str::contains(format!(
-            "Remove low-complexity k-mers: {} (from index)",
-            expected
-        )));
+        let state = if expected == "true" { "REMOVED" } else { "KEPT" };
+        search_cmd
+            .assert()
+            .success()
+            .stderr(predicate::str::contains(format!(
+                "Index: low-complexity k-mers were {state} when it was built"
+            )))
+            .stderr(predicate::str::contains(format!(
+                "This search: low-complexity k-mers are {state} from query sketches"
+            )))
+            .stderr(predicate::str::contains("(matching the index)"))
+            // Agreeing with the index must not warn.
+            .stderr(predicate::str::contains("WARNING").not());
+    }
+
+    Ok(())
+}
+
+/// Overriding the index's setting at search time is allowed but warned about,
+/// because containment is only comparable when both sides drop the same k-mers.
+#[test]
+fn test_cli_search_remove_low_complexity_override_warns() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temp_dir = tempdir()?;
+    let index_path = temp_dir.path().join("kept.db");
+
+    let mut index_cmd = Command::cargo_bin("kmerseek")?;
+    index_cmd.args([
+        "index",
+        "--input",
+        TEST_FASTA_GZ,
+        "--output",
+        index_path.to_str().unwrap(),
+        "--ksize",
+        "12",
+        "--encoding",
+        "hp",
+    ]);
+    index_cmd.assert().success();
+
+    let mut search_cmd = Command::cargo_bin("kmerseek")?;
+    search_cmd.args([
+        "search",
+        "--query",
+        TEST_CED9_FASTA,
+        "--target",
+        index_path.to_str().unwrap(),
+        "--ksize",
+        "12",
+        "--encoding",
+        "hp",
+        "--remove-low-complexity",
+    ]);
+
+    search_cmd
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Index: low-complexity k-mers were KEPT"))
+        .stderr(predicate::str::contains(
+            "This search: low-complexity k-mers are REMOVED from query sketches",
+        ))
+        .stderr(predicate::str::contains("WARNING: this disagrees with the index"));
+
+    Ok(())
+}
+
+/// The results file records the setting per row, so a CSV is self-describing
+/// without needing the command line that produced it.
+#[test]
+fn test_cli_search_csv_records_remove_low_complexity() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+
+    for (flag, expected) in [(true, "true"), (false, "false")] {
+        let index_path = temp_dir.path().join(format!("csv_{flag}.db"));
+        let csv_path = temp_dir.path().join(format!("csv_{flag}.csv"));
+
+        let mut index_cmd = Command::cargo_bin("kmerseek")?;
+        index_cmd.args([
+            "index",
+            "--input",
+            TEST_FASTA_GZ,
+            "--output",
+            index_path.to_str().unwrap(),
+            "--ksize",
+            "12",
+            "--encoding",
+            "hp",
+        ]);
+        if flag {
+            index_cmd.arg("--remove-low-complexity");
+        }
+        index_cmd.assert().success();
+
+        let mut search_cmd = Command::cargo_bin("kmerseek")?;
+        search_cmd.args([
+            "search",
+            "--query",
+            TEST_CED9_FASTA,
+            "--target",
+            index_path.to_str().unwrap(),
+            "--output",
+            csv_path.to_str().unwrap(),
+            "--ksize",
+            "12",
+            "--encoding",
+            "hp",
+        ]);
+        search_cmd.assert().success();
+
+        let csv = std::fs::read_to_string(&csv_path)?;
+        let mut lines = csv.lines();
+        let header: Vec<&str> = lines.next().expect("header row").split(',').collect();
+        let col = header
+            .iter()
+            .position(|h| *h == "remove_low_complexity")
+            .expect("remove_low_complexity column");
+        // It sits with the other run metadata rather than at the end.
+        assert_eq!(header[col - 1], "moltype");
+
+        let first = lines.next().expect("at least one result row");
+        assert_eq!(first.split(',').nth(col), Some(expected));
     }
 
     Ok(())


### PR DESCRIPTION
Me: The most common hydrophobic-polar k-mers are overwhelmingly {h}_n and {p}_n homopolymer runs, which skew the results because of spurious matches to repetitive sequences. This adds the option to remove low complexity k-mers when building the index, and also takes into account the low complexity k-mers at search time, so the additional low complexity k-mers aren't adding to the denominator in the Jaccard calculation.

I'd like this to be included in v0.4.0 https://github.com/seanome/kmerseek/pull/34 for future testing

---
## What

Adds an opt-in `--remove-low-complexity` flag to `kmerseek index`. Low-complexity k-mers — homopolymer runs like a poly-glutamate tract (`EEEEE`) or, under a reduced alphabet, an all-hydrophobic window (`hhhhh`) — are abundant and carry little discriminative signal.

**Off by default.** Existing indexes and workflows are unaffected.

```bash
kmerseek index -i proteome.fasta --ksize 10 --encoding hp --remove-low-complexity
```

## Two independent checks

Per k-mer, when enabled:

1. **Raw amino-acid** window — any encoding. Catches `EEEEE`.
2. **HP-encoded** window — `hp`-family encodings only. Catches windows that aren't raw homopolymers but still collapse to one symbol: `LIVMA` is five different residues that all encode to `h`.

Only *exact* homopolymers are removed. A near-homopolymer like `hhhhhhhhhp` is kept — see follow-up below.

## The setting is stored in the index, and search reuses it

This is the part that matters most for correctness. Containment is `intersection / query_size`. If the index removed these k-mers but queries kept them, those k-mers would match nothing while still inflating the denominator — deflating scores for exactly the queries that contain low-complexity regions.

So the flag is persisted and read back at search time. You don't repeat it when searching:

```
Remove low-complexity k-mers: true (from index)
```

Verified on the bcl2 test set: containment shifts on **all 25 shared query/target pairs**, in both directions — the denominator shrinks while some intersecting k-mers also drop.

### Persistence, and index versioning

`remove_low_complexity` is a real field on `ProteomeIndexMetadata`, and `save_state` stamps the writing kmerseek version (`CARGO_PKG_VERSION`) into a `kmerseek_version` key.

bincode is not self-describing, so that key doubles as the metadata layout marker: stamped indexes deserialize with the current struct, unstamped ones go through `LegacyProteomeIndexMetadata` and default the flag to `false` — correct, since they kept every k-mer. Old indexes still open; the field is first-class going forward. `SCHEMA_VERSION` goes 1 → 2 to reflect the layout change, and `read_kmerseek_version()` is public so you can check what built an index.

### Counting costs nothing extra

The removal tallies accumulate into two `AtomicUsize` totals on `ProteomeIndex` as each signature is built, so `low_complexity_counts()` is an O(1) load with no second pass over the signature map. Atomics because `create_protein_signature` takes `&self` and `process_fasta` drives it from a `par_iter`.

## Filenames don't collide

The point of the flag is A/B comparison, so auto-generated names gain a `.nolowcomplexity` segment. Otherwise indexing the same FASTA both ways would silently clobber the first database.

```
proteome.fasta.hp.k10.scaled1.kmerseek.rocksdb                  # default
proteome.fasta.hp.k10.scaled1.nolowcomplexity.kmerseek.rocksdb  # --remove-low-complexity
```

## Indexing reports what it removed

So you can tell whether the flag mattered without rebuilding and diffing:

```
Removed 75 of 9063 k-mer windows as low-complexity (0.83%)
```

## Drive-by cleanup

Removes `ProteomeIndex::process_kmers` — a second, unfiltered k-mer walk that nothing but tests still called (`create_protein_signature` stopped using it). It turned out to be the sole consumer of the `encoding_fn` field and four imports, so those came out too. Moltype validation is preserved at each site by the existing `get_hash_function_from_moltype` call. Its tests already exercised `add_protein` directly and are renamed to match.

## Naming

`remove` rather than `filter` throughout, since "filter" doesn't say which direction — filter *in* or filter *out*?

## Testing

**142 tests pass**, clean build with zero warnings, `cargo fmt --check` clean.

Seven tests cover this feature specifically:

- `is_homopolymer_kmer` detects runs / rejects mixed k-mers
- Toggle on/off at the `ProteinSketch` level and through `ProteomeIndex`
- Raw amino-acid removal for plain `protein` moltype, using a genuine 11-residue poly-E tract from human FKBP8 (UniProt Q14318, residues 26–55) already in the repo's test FASTA — real biology, not an invented motif
- Persistence round-trip through `save_state` → `open_for_search`
- A forged pre-versioning index still loads through the legacy metadata layout, with the flag defaulting to `false`
- `save_state` stamps the kmerseek version
- Custom `hp_*` alphabets, which take a different encode-and-check path from the built-in `hp`
- Index-level count aggregation across multiple signatures, and the builder's `remove_low_complexity`
- CLI round-trip: index with the flag, then search without it and assert the setting is recovered
- CLI filename collision

## Follow-up, not in this PR

Broadening beyond exact homopolymers. A k-mer frequency histogram on real data shows the top offenders are 9-of-10 homopolymers that this PR's strict check lets through:

```
hhhhhhhhhp: 653
hppppppppp: 651
phhhhhhhhh: 645
```

Catching those needs a fuzzier threshold (max run length, or "at most N minority residues") — a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
