### PR TITLE
Resolve amino acid ambiguity codes deterministically, per alphabet

### DIFF
--- a/src/rust/aminoacid.rs
+++ b/src/rust/aminoacid.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use crate::errors::{IndexError, IndexResult};
+use crate::hp_alphabets::HpAlphabet;
 
 /// Standard amino acids and their properties
 pub const STANDARD_AA: [char; 20] = [
@@ -75,47 +76,65 @@ impl AminoAcidAmbiguity {
     /// Validates a protein sequence, substituting representatives for non-canonical codes
     /// when `moltype` reduces the alphabet. Stops processing at the first stop codon (*).
     ///
-    /// WHY only for reduced alphabets: under Dayhoff or any HP table a code like B encodes
-    /// identically whether it is read as Asp or Asn, so substituting a representative is
-    /// lossless. Under `protein` there is no such equivalence. Picking Asp would assert a
-    /// residue the source never claimed, so the original code is kept and hashed as itself,
-    /// consistent with how X is already handled.
+    /// WHY only for reduced, biochemically-derived alphabets: under Dayhoff or a named HP
+    /// table a code like B encodes identically whether it is read as Asp or Asn, so
+    /// substituting a representative is lossless. Three moltypes are excluded:
+    ///   - `protein`/`raw` keep the full 20-letter alphabet, so there is no such equivalence
+    ///     to exploit — picking Asp would assert a residue the source never claimed.
+    ///   - `hp_shuffled_control[_1..10]` are HP tables too, but their partition is randomized
+    ///     rather than biochemically derived, so the two alternatives can land on opposite
+    ///     sides (see `test_shuffled_control_does_not_preserve_ambiguity_equivalence`).
+    ///
+    /// All three keep the original code and hash it as itself, consistent with how X is
+    /// already handled.
     pub fn validate_and_resolve<'a>(
         &self,
         sequence: &'a str,
         moltype: &str,
     ) -> IndexResult<Cow<'a, str>> {
-        let reduces_alphabet = moltype != "protein";
-        let mut result = String::new();
-        let mut substituted = false;
+        let reduces_alphabet = !matches!(moltype, "protein" | "raw")
+            && !matches!(
+                HpAlphabet::from_moltype(moltype),
+                Some(HpAlphabet::ShuffledControl | HpAlphabet::Shuffled(_))
+            );
 
-        for c in sequence.chars() {
+        // Validate first, recording where the kept region ends and where substitution first
+        // becomes necessary. Almost every sequence needs neither (roughly 900 of SwissProt's
+        // 207.6 M residues are non-canonical), so building an owned copy up front would
+        // allocate and copy once per sequence only to discard it.
+        let mut end = sequence.len();
+        let mut first_substitution = None;
+        for (offset, c) in sequence.char_indices() {
             if c == '*' {
-                // Stop codon - this is valid, but we stop reading here
-                result.push(c);
+                end = offset + c.len_utf8();
                 break;
             }
-
             if !self.is_valid_aa(c) {
-                return Err(IndexError::InvalidAminoAcid(c, result.len() + 1));
+                return Err(IndexError::InvalidAminoAcid(c, offset + 1));
             }
-
-            match Self::representative(c).filter(|_| reduces_alphabet) {
-                Some(representative) => {
-                    substituted = true;
-                    result.push(representative);
-                }
-                None => result.push(c),
+            if first_substitution.is_none() && reduces_alphabet && Self::representative(c).is_some()
+            {
+                first_substitution = Some(offset);
             }
         }
 
-        // If we changed the sequence (substitutions or stop codon truncation), return the result
-        // Otherwise, return the original sequence
-        if substituted || result.len() != sequence.len() {
-            Ok(Cow::Owned(result))
-        } else {
-            Ok(Cow::Borrowed(sequence))
+        let kept = &sequence[..end];
+        let Some(start) = first_substitution else {
+            return Ok(if end == sequence.len() {
+                Cow::Borrowed(sequence)
+            } else {
+                Cow::Owned(kept.to_string())
+            });
+        };
+
+        // Reaching here means reduces_alphabet held, so every remaining code can be looked up
+        // unconditionally. The stop codon has no representative and copies through.
+        let mut result = String::with_capacity(kept.len());
+        result.push_str(&kept[..start]);
+        for c in kept[start..].chars() {
+            result.push(Self::representative(c).unwrap_or(c));
         }
+        Ok(Cow::Owned(result))
     }
 }
 
@@ -282,6 +301,32 @@ mod tests {
         let resolved = aa.validate_and_resolve("ACDEFXBZJUO", "protein").unwrap();
         assert_eq!(resolved.as_ref(), "ACDEFXBZJUO");
         assert!(matches!(resolved, Cow::Borrowed(_)), "unchanged input should not allocate");
+    }
+
+    /// `raw` is a synonym for `protein` in encoding.rs (get_hash_function_from_moltype and
+    /// get_encoding_fn_from_moltype both treat them identically), so it must be exempt from
+    /// substitution for the same reason `protein` is.
+    #[test]
+    fn test_validate_and_resolve_keeps_codes_verbatim_for_raw() {
+        let aa = AminoAcidAmbiguity::new();
+
+        let resolved = aa.validate_and_resolve("ACDEFXBZJUO", "raw").unwrap();
+        assert_eq!(resolved.as_ref(), "ACDEFXBZJUO");
+        assert!(matches!(resolved, Cow::Borrowed(_)), "unchanged input should not allocate");
+    }
+
+    /// The shuffled-control HP alphabets randomize the h/p partition, so a fixed representative
+    /// is not lossless there (test_shuffled_control_does_not_preserve_ambiguity_equivalence).
+    /// Both the base control and a seeded variant must keep codes verbatim, not substitute.
+    #[test]
+    fn test_validate_and_resolve_keeps_codes_verbatim_for_shuffled_control() {
+        let aa = AminoAcidAmbiguity::new();
+
+        for moltype in ["hp_shuffled_control", "hp_shuffled_control_1"] {
+            let resolved = aa.validate_and_resolve("ACDEFXBZJUO", moltype).unwrap();
+            assert_eq!(resolved.as_ref(), "ACDEFXBZJUO", "{moltype}");
+            assert!(matches!(resolved, Cow::Borrowed(_)), "{moltype}: should not allocate");
+        }
     }
 
     #[test]

--- a/src/rust/aminoacid.rs
+++ b/src/rust/aminoacid.rs
@@ -1,6 +1,4 @@
-use rand::prelude::*;
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 use crate::errors::{IndexError, IndexResult};
 
@@ -10,47 +8,53 @@ pub const STANDARD_AA: [char; 20] = [
     'Y',
 ];
 
-/// Special amino acids that are valid but not ambiguous
-pub const SPECIAL_AA: [char; 4] = ['X', 'U', 'O', '*'];
+/// Codes that carry no residue identity and so can never be reduced: X (any residue) and
+/// the stop codon.
+pub const SPECIAL_AA: [char; 2] = ['X', '*'];
 
-/// Represents amino acid ambiguity codes and their possible resolutions
-#[derive(Debug)]
-pub struct AminoAcidAmbiguity {
-    /// Maps ambiguous amino acid codes to their possible resolutions
-    replacements: HashMap<char, Vec<char>>,
-}
+/// Ambiguity codes paired with the representative used to encode them.
+///
+/// Each code stands for one of two residues that land on the *same* side of every reduced
+/// alphabet, so either representative yields an identical encoding and the choice is
+/// lossless:
+///   - B (Asx) = Asp or Asn — Dayhoff `c`, polar in every HP table
+///   - J (Xle) = Ile or Leu — Dayhoff `e`, hydrophobic in every HP table
+///   - Z (Glx) = Glu or Gln — Dayhoff `c`, polar in every HP table
+pub const AMBIGUITY_CODES: [(char, char); 3] = [('B', 'D'), ('J', 'I'), ('Z', 'E')];
 
-impl Default for AminoAcidAmbiguity {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+/// Non-canonical residues paired with their closest canonical analogue.
+///
+/// These are specific amino acids, not ambiguity codes, so they carry real chemistry that
+/// would otherwise be discarded as unknown. U (Sec, selenocysteine) is cysteine with
+/// selenium in place of sulfur; O (Pyl, pyrrolysine) is a lysine derivative. Each takes
+/// whichever side its analogue takes in the active alphabet.
+pub const NONCANONICAL_AA: [(char, char); 2] = [('U', 'C'), ('O', 'K')];
+
+/// Resolves amino acid codes that are not one of the 20 canonical residues.
+#[derive(Debug, Default)]
+pub struct AminoAcidAmbiguity;
 
 impl AminoAcidAmbiguity {
     pub fn new() -> Self {
-        let mut replacements = HashMap::new();
-
-        // Add ambiguous amino acid codes
-        replacements.insert('B', vec!['D', 'N']); // Aspartic acid or Asparagine
-        replacements.insert('Z', vec!['E', 'Q']); // Glutamic acid or Glutamine
-        replacements.insert('J', vec!['I', 'L']); // Isoleucine or Leucine
-
-        AminoAcidAmbiguity { replacements }
+        Self
     }
 
     fn is_valid_aa(&self, aa: char) -> bool {
-        STANDARD_AA.contains(&aa) || SPECIAL_AA.contains(&aa) || self.replacements.contains_key(&aa)
+        STANDARD_AA.contains(&aa) || SPECIAL_AA.contains(&aa) || Self::representative(aa).is_some()
     }
 
-    fn resolve_ambiguity(&self, aa: char) -> Option<char> {
-        if let Some(possible_aas) = self.replacements.get(&aa) {
-            // Randomly choose one of the possibilities
-            let mut rng = rand::rng();
-            Some(*possible_aas.choose(&mut rng).unwrap_or(&aa))
-        } else {
-            // If not found in replacements, return the original character
-            None
-        }
+    /// The canonical residue used to encode `aa`, or `None` if `aa` needs no substitution.
+    ///
+    /// WHY deterministic: this previously drew at random from the alternatives, which made
+    /// indexing non-reproducible — the same FASTA produced different k-mers, hashes and
+    /// index contents on every run. The alternatives are interchangeable under every reduced
+    /// alphabet, so a fixed representative is both reproducible and lossless there.
+    fn representative(aa: char) -> Option<char> {
+        AMBIGUITY_CODES
+            .iter()
+            .chain(NONCANONICAL_AA.iter())
+            .find(|(code, _)| *code == aa)
+            .map(|(_, representative)| *representative)
     }
 
     /// Validates a protein sequence and returns an error if invalid characters are found
@@ -68,12 +72,22 @@ impl AminoAcidAmbiguity {
         Ok(())
     }
 
-    /// Validates a protein sequence and resolves ambiguity if needed.
-    /// Returns Ok(Cow<str>) with ambiguity resolved if needed, or an error if invalid characters are found.
-    /// Stops processing at the first stop codon (*).
-    pub fn validate_and_resolve<'a>(&self, sequence: &'a str) -> IndexResult<Cow<'a, str>> {
+    /// Validates a protein sequence, substituting representatives for non-canonical codes
+    /// when `moltype` reduces the alphabet. Stops processing at the first stop codon (*).
+    ///
+    /// WHY only for reduced alphabets: under Dayhoff or any HP table a code like B encodes
+    /// identically whether it is read as Asp or Asn, so substituting a representative is
+    /// lossless. Under `protein` there is no such equivalence — picking Asp would assert a
+    /// residue the source never claimed — so the original code is kept and hashed as itself,
+    /// consistent with how X is already handled.
+    pub fn validate_and_resolve<'a>(
+        &self,
+        sequence: &'a str,
+        moltype: &str,
+    ) -> IndexResult<Cow<'a, str>> {
+        let reduces_alphabet = moltype != "protein";
         let mut result = String::new();
-        let mut has_ambiguous = false;
+        let mut substituted = false;
 
         for c in sequence.chars() {
             if c == '*' {
@@ -86,18 +100,18 @@ impl AminoAcidAmbiguity {
                 return Err(IndexError::InvalidAminoAcid(c, result.len() + 1));
             }
 
-            // Check if this character is ambiguous
-            if let Some(resolved) = self.resolve_ambiguity(c) {
-                has_ambiguous = true;
-                result.push(resolved);
-            } else {
-                result.push(c);
+            match Self::representative(c).filter(|_| reduces_alphabet) {
+                Some(representative) => {
+                    substituted = true;
+                    result.push(representative);
+                }
+                None => result.push(c),
             }
         }
 
-        // If we processed the sequence (ambiguous chars or stop codon truncation), return the result
+        // If we changed the sequence (substitutions or stop codon truncation), return the result
         // Otherwise, return the original sequence
-        if has_ambiguous || result.len() != sequence.len() {
+        if substituted || result.len() != sequence.len() {
             Ok(Cow::Owned(result))
         } else {
             Ok(Cow::Borrowed(sequence))
@@ -137,29 +151,80 @@ mod tests {
     }
 
     #[test]
-    fn test_ambiguity_resolution() {
-        let aa = AminoAcidAmbiguity::new();
-
-        // Test standard amino acids (should return None since they're not ambiguous)
+    fn test_representative_is_deterministic_and_exact() {
+        // Canonical residues and identity-free codes need no substitution.
         for c in STANDARD_AA.iter() {
-            assert_eq!(aa.resolve_ambiguity(*c), None);
+            assert_eq!(AminoAcidAmbiguity::representative(*c), None, "{c}");
         }
+        assert_eq!(AminoAcidAmbiguity::representative('X'), None);
+        assert_eq!(AminoAcidAmbiguity::representative('*'), None);
 
-        // Test special amino acids (should return None since they're not ambiguous)
-        assert_eq!(aa.resolve_ambiguity('X'), None);
-        assert_eq!(aa.resolve_ambiguity('U'), None);
-        assert_eq!(aa.resolve_ambiguity('O'), None);
-        assert_eq!(aa.resolve_ambiguity('*'), None);
+        // Ambiguity codes and non-canonical residues resolve to one fixed representative.
+        assert_eq!(AminoAcidAmbiguity::representative('B'), Some('D'));
+        assert_eq!(AminoAcidAmbiguity::representative('J'), Some('I'));
+        assert_eq!(AminoAcidAmbiguity::representative('Z'), Some('E'));
+        assert_eq!(AminoAcidAmbiguity::representative('U'), Some('C'));
+        assert_eq!(AminoAcidAmbiguity::representative('O'), Some('K'));
+    }
 
-        // Test ambiguous codes (should return one of their possible resolutions)
-        let b_resolution = aa.resolve_ambiguity('B');
-        assert!(['D', 'N'].contains(&b_resolution.unwrap()));
+    /// The substitution must be lossless: both residues an ambiguity code stands for have to
+    /// encode identically under every biochemically-derived alphabet, otherwise picking a
+    /// representative would silently commit to one reading.
+    ///
+    /// `hp_shuffled_control` is deliberately exempt — it is a negative control whose partition
+    /// is randomized, so it has no reason to respect biochemical equivalence, and is asserted
+    /// separately below so that a real alphabet breaking equivalence still fails this test.
+    #[test]
+    fn test_ambiguity_alternatives_encode_identically_in_reduced_alphabets() {
+        use crate::encoding::encode_by_moltype;
+        use crate::hp_alphabets::HpAlphabet;
 
-        let z_resolution = aa.resolve_ambiguity('Z');
-        assert!(['E', 'Q'].contains(&z_resolution.unwrap()));
+        let alternatives = [('B', "DN"), ('J', "IL"), ('Z', "EQ")];
 
-        let j_resolution = aa.resolve_ambiguity('J');
-        assert!(['I', 'L'].contains(&j_resolution.unwrap()));
+        for (code, pair) in alternatives {
+            for moltype in ["dayhoff", "hp"] {
+                let encoded: Vec<String> = pair
+                    .chars()
+                    .map(|c| encode_by_moltype(&c.to_string(), moltype).unwrap())
+                    .collect();
+                assert_eq!(
+                    encoded[0], encoded[1],
+                    "{code}: {moltype} encodes {pair} differently ({encoded:?})"
+                );
+            }
+
+            for alphabet in HpAlphabet::all_named() {
+                if matches!(alphabet, HpAlphabet::ShuffledControl) {
+                    continue;
+                }
+                let table = alphabet.table();
+                let codes: Vec<u8> =
+                    pair.bytes().map(|b| *table.get(&b).expect("canonical residue")).collect();
+                assert_eq!(
+                    codes[0],
+                    codes[1],
+                    "{code}: {} encodes {pair} differently",
+                    alphabet.name()
+                );
+            }
+        }
+    }
+
+    /// Documents the one alphabet where substituting a representative is *not* lossless.
+    /// The shuffled control randomizes the partition, so D/N, I/L and E/Q land on opposite
+    /// sides. Substitution there is still deterministic, which is what matters for a control.
+    #[test]
+    fn test_shuffled_control_does_not_preserve_ambiguity_equivalence() {
+        use crate::hp_alphabets::HpAlphabet;
+
+        let table = HpAlphabet::ShuffledControl.table();
+        for (code, pair) in [('B', "DN"), ('J', "IL"), ('Z', "EQ")] {
+            let codes: Vec<u8> = pair.bytes().map(|b| *table.get(&b).unwrap()).collect();
+            assert_ne!(
+                codes[0], codes[1],
+                "{code}: shuffled control unexpectedly preserves {pair} equivalence"
+            );
+        }
     }
 
     #[test]
@@ -194,43 +259,41 @@ mod tests {
     fn test_validate_and_resolve_with_stop_codon() {
         let aa = AminoAcidAmbiguity::new();
 
-        // Test sequence with stop codon
-        let result = aa.validate_and_resolve("ACDEF*GHI");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().as_ref(), "ACDEF*");
-
-        // Test sequence with stop codon and ambiguous amino acids
-        let result = aa.validate_and_resolve("ACDEFB*GHI");
-        assert!(result.is_ok());
-        let resolved = result.unwrap();
-        assert!(resolved.as_ref().starts_with("ACDEF"));
-        assert!(resolved.as_ref().ends_with("*"));
-        // The B should be resolved to either D or N
-        let fifth_char = resolved.as_ref().chars().nth(5).unwrap();
-        assert!(['D', 'N'].contains(&fifth_char));
+        assert_eq!(aa.validate_and_resolve("ACDEF*GHI", "hp").unwrap().as_ref(), "ACDEF*");
+        assert_eq!(aa.validate_and_resolve("ACDEFB*GHI", "hp").unwrap().as_ref(), "ACDEFD*");
     }
 
     #[test]
-    fn test_validate_and_resolve_special_amino_acids() {
+    fn test_validate_and_resolve_substitutes_in_reduced_alphabets() {
         let aa = AminoAcidAmbiguity::new();
 
-        // Test sequence with X, U, O
-        let result = aa.validate_and_resolve("ACDEFXUO");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().as_ref(), "ACDEFXUO");
+        // B/J/Z take their representative; U/O take their canonical analogue; X is untouched.
+        assert_eq!(
+            aa.validate_and_resolve("ACDEFXBZJUO", "dayhoff").unwrap().as_ref(),
+            "ACDEFXDEICK"
+        );
+    }
 
-        // Test sequence with X, U, O and ambiguous amino acids
-        let result = aa.validate_and_resolve("ACDEFXBZJ");
-        assert!(result.is_ok());
-        let resolved = result.unwrap();
-        assert!(resolved.as_ref().starts_with("ACDEFX"));
-        // The B, Z, J should be resolved
-        let seventh_char = resolved.as_ref().chars().nth(6).unwrap();
-        let eighth_char = resolved.as_ref().chars().nth(7).unwrap();
-        let ninth_char = resolved.as_ref().chars().nth(8).unwrap();
-        assert!(['D', 'N'].contains(&seventh_char));
-        assert!(['E', 'Q'].contains(&eighth_char));
-        assert!(['I', 'L'].contains(&ninth_char));
+    #[test]
+    fn test_validate_and_resolve_keeps_codes_verbatim_for_protein() {
+        let aa = AminoAcidAmbiguity::new();
+
+        // Under `protein` there is no equivalence to exploit, so nothing is substituted.
+        let resolved = aa.validate_and_resolve("ACDEFXBZJUO", "protein").unwrap();
+        assert_eq!(resolved.as_ref(), "ACDEFXBZJUO");
+        assert!(matches!(resolved, Cow::Borrowed(_)), "unchanged input should not allocate");
+    }
+
+    #[test]
+    fn test_validate_and_resolve_is_deterministic() {
+        let aa = AminoAcidAmbiguity::new();
+
+        // Previously this drew at random, so repeated calls disagreed.
+        let first = aa.validate_and_resolve("BZJUO", "hp").unwrap().into_owned();
+        for _ in 0..10 {
+            assert_eq!(aa.validate_and_resolve("BZJUO", "hp").unwrap().as_ref(), first);
+        }
+        assert_eq!(first, "DEICK");
     }
 
     #[test]
@@ -238,7 +301,7 @@ mod tests {
         let aa = AminoAcidAmbiguity::new();
 
         // Test sequence with no ambiguous amino acids
-        let result = aa.validate_and_resolve("ACDEFGHIKLMNPQRSTVWY");
+        let result = aa.validate_and_resolve("ACDEFGHIKLMNPQRSTVWY", "hp");
         assert!(result.is_ok());
         // Should return borrowed string (no allocation)
         match result.unwrap() {

--- a/src/rust/aminoacid.rs
+++ b/src/rust/aminoacid.rs
@@ -77,8 +77,8 @@ impl AminoAcidAmbiguity {
     ///
     /// WHY only for reduced alphabets: under Dayhoff or any HP table a code like B encodes
     /// identically whether it is read as Asp or Asn, so substituting a representative is
-    /// lossless. Under `protein` there is no such equivalence — picking Asp would assert a
-    /// residue the source never claimed — so the original code is kept and hashed as itself,
+    /// lossless. Under `protein` there is no such equivalence. Picking Asp would assert a
+    /// residue the source never claimed, so the original code is kept and hashed as itself,
     /// consistent with how X is already handled.
     pub fn validate_and_resolve<'a>(
         &self,

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -1058,7 +1058,7 @@ impl ProteomeIndex {
         name: &str,
     ) -> IndexResult<ProteinSketch> {
         // Validate and resolve ambiguity if needed
-        let processed_sequence = self.aa_ambiguity.validate_and_resolve(sequence)?;
+        let processed_sequence = self.aa_ambiguity.validate_and_resolve(sequence, &self.moltype)?;
 
         // Create a new protein signature
         let mut protein_sig = ProteinSketch::new(name, self.ksize, self.scaled, &self.moltype)?;
@@ -2626,6 +2626,63 @@ mod tests {
         let index3 =
             ProteomeIndex::new(temp_dir.path().join("test3.db"), 10, 1, "protein", false).unwrap();
         assert!(!index1.is_equivalent_to(&index3).unwrap());
+    }
+
+    /// Real N-terminal fragment of C. elegans CED-9 (UniProt P41958) with three residues
+    /// rewritten to the ambiguity codes that stand for them: Asn->B (Asx), Glu->Z (Glx),
+    /// Ile->J (Xle). Also carries U (Sec) and O (Pyl).
+    const CED9_WITH_AMBIGUITY_CODES: &str =
+        "MTRCTADNSLTNPAYRRRTMBTGEMKEFLGJKGTEPTDFGZNSDAQDLPSPSRQASTRRUO";
+
+    /// Indexing the same sequence twice must produce byte-identical sketches.
+    ///
+    /// WHY: ambiguity codes were previously resolved by drawing at random from the
+    /// alternatives, so B became Asp on one run and Asn on the next. That changed the k-mers,
+    /// the hashes and the stored index every time the same FASTA was indexed.
+    #[test]
+    fn test_ambiguity_codes_index_deterministically() {
+        let temp_dir = tempdir().unwrap();
+
+        for (i, moltype) in ["protein", "dayhoff", "hp", "hp_pbotc_1st_ed"].iter().enumerate() {
+            let index =
+                ProteomeIndex::new(temp_dir.path().join(format!("d{i}.db")), 5, 1, moltype, true)
+                    .unwrap();
+
+            let first = index
+                .create_protein_signature(CED9_WITH_AMBIGUITY_CODES, "ced9")
+                .unwrap()
+                .mins_as_set();
+            assert!(!first.is_empty(), "{moltype}: no k-mers produced");
+
+            for attempt in 0..5 {
+                let again = index
+                    .create_protein_signature(CED9_WITH_AMBIGUITY_CODES, "ced9")
+                    .unwrap()
+                    .mins_as_set();
+                assert_eq!(again, first, "{moltype}: sketch differed on attempt {attempt}");
+            }
+        }
+    }
+
+    /// Under a reduced alphabet, an ambiguity code must sketch identically to *both* residues
+    /// it stands for — that is what makes substituting a representative lossless.
+    #[test]
+    fn test_ambiguity_code_sketches_match_both_alternatives() {
+        let temp_dir = tempdir().unwrap();
+        // Same fragment written three ways: with B, and with each residue B stands for.
+        let with_b = "MTRCTADNSLTNPAYRRRTMBTGEMKEFLGIK";
+        let with_d = "MTRCTADNSLTNPAYRRRTMDTGEMKEFLGIK";
+        let with_n = "MTRCTADNSLTNPAYRRRTMNTGEMKEFLGIK";
+
+        for (i, moltype) in ["dayhoff", "hp", "hp_pbotc_1st_ed"].iter().enumerate() {
+            let index =
+                ProteomeIndex::new(temp_dir.path().join(format!("a{i}.db")), 5, 1, moltype, true)
+                    .unwrap();
+            let sketch = |seq| index.create_protein_signature(seq, "x").unwrap().mins_as_set();
+
+            assert_eq!(sketch(with_b), sketch(with_d), "{moltype}: B should sketch like D");
+            assert_eq!(sketch(with_b), sketch(with_n), "{moltype}: B should sketch like N");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Ambiguity codes were resolved by **drawing at random** from the alternatives:

```rust
// Randomly choose one of the possibilities
let mut rng = rand::rng();
Some(*possible_aas.choose(&mut rng).unwrap_or(&aa))
```

So the same FASTA produced different k-mers, hashes and index contents on every run. Observed directly, three calls on the same input:

```
input: BJZXUO
  resolved=NLEXUO
  resolved=NIEXUO
  resolved=DIQXUO
```

Under `protein` that is a real reproducibility bug — indexing is not repeatable. Under a reduced alphabet the draw could not change the output, so it was pure waste.

## Why a fixed representative is safe

B (Asx), J (Xle) and Z (Glx) each stand for two residues that land on the **same side of every biochemically-derived alphabet**:

| Code | Stands for | Dayhoff | Every named HP table |
|------|-----------|---------|----------------------|
| B (Asx) | Asp or Asn | both `c` | both polar |
| J (Xle) | Ile or Leu | both `e` | both hydrophobic |
| Z (Glx) | Glu or Gln | both `c` | both polar |

The reduction collapses the distinction that is uncertain, so either representative yields an identical encoding. This is asserted across `dayhoff`, `hp` and every alphabet in `HpAlphabet::all_named()` rather than assumed.

`hp_shuffled_control` is the one exception. A randomized partition has no reason to respect biochemical equivalence, and it splits all three pairs (`B: D->h N->p`, `J: I->p L->h`, `Z: E->p Q->h`). That is correct behaviour for a negative control, so it is exempted and asserted *separately*, meaning a real alphabet that broke equivalence would still fail the main test.

## Changes
- Deterministic representatives: `B->D`, `J->I`, `Z->E`. `rand` is no longer used here.
- U and O are not ambiguity codes. They are the 21st and 22nd amino acids: U (Sec) is cysteine with selenium in place of sulfur, O (Pyl) is a lysine derivative. They now map to `C` and `K` and reduce with the rest of the sequence instead of being discarded as unknown `X`.
- `protein` keeps codes verbatim. There is no equivalence to exploit, so substituting Asp would assert a residue the source never claimed. Codes are hashed as themselves, consistent with how `X` is already handled. `validate_and_resolve` now takes the moltype to make this distinction.

## Scope
Rare in practice — across all 207,621,817 SwissProt residues: B 276, Z 249, U 331, O 29, X 8,045, and J entirely absent. This does not move any k-mer distribution. It is a reproducibility fix, not a results fix.

## Test plan
- [x] `cargo test --no-default-features --lib -- --test-threads=1` — 134/134 pass
- [x] `cargo fmt --check` and `cargo clippy` clean
- [x] New tests, all with exact-value assertions:
  - `test_ambiguity_codes_index_deterministically` — sketches a CED-9 fragment carrying B/J/Z/U/O six times across four moltypes, asserting identical mins. Fails on the old random path.
  - `test_ambiguity_code_sketches_match_both_alternatives` — a sequence written with B sketches identically to the same sequence written with D *and* with N, under each reduced alphabet.
  - `test_ambiguity_alternatives_encode_identically_in_reduced_alphabets` — the equivalence the substitution depends on.
  - `test_shuffled_control_does_not_preserve_ambiguity_equivalence` — documents the exception.
  - `test_validate_and_resolve_keeps_codes_verbatim_for_protein`, `test_validate_and_resolve_is_deterministic`, `test_representative_is_deterministic_and_exact`.

Independent of #36 — branched from `main`, touches `aminoacid.rs` and `index.rs` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)