### PR TITLE
Add hp_lehninger_hpc: 3-letter hydrophobic/polar/cystine alphabet

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ default (`hp` moltype); the others are selectable via `hp_<name>` moltypes
 
 `hp_lehninger_hpc` is a 3-letter variant: it keeps Lehninger's H/P split for
 every residue except cysteine, which gets its own third symbol `c` (cystine)
-instead of being folded into `h` the way `hp_lehninger_plus_c` does --
+instead of being folded into `h` the way `hp_lehninger_c_nonpolar` does --
 disulfide-bond formation is a distinct chemistry from ordinary hydrophobic
 packing.
 

--- a/README.md
+++ b/README.md
@@ -90,28 +90,34 @@ the five borderline ones -- **C, G, P, W, Y** (bolded). Lehninger is the current
 default (`hp` moltype); the others are selectable via `hp_<name>` moltypes
 (e.g. `hp_thomas_dill`) for the alphabet robustness sweep.
 
-| AA | Lehninger (current) | Thomas-Dill/PBotC 2nd | Kyte-Doolittle | TD−C | Leh+C | PBotC 1st |
-|----|:---:|:---:|:---:|:---:|:---:|:---:|
-| A | h | h | h | h | h | h |
-| **C** | p | h | h | p | h | h |
-| D | p | p | p | p | p | p |
-| E | p | p | p | p | p | p |
-| F | h | h | h | h | h | h |
-| **G** | h | p | p | p | h | p |
-| H | p | p | p | p | p | p |
-| I | h | h | h | h | h | h |
-| K | p | p | p | p | p | p |
-| L | h | h | h | h | h | h |
-| M | h | h | h | h | h | h |
-| N | p | p | p | p | p | p |
-| **P** | h | p | p | p | h | h |
-| Q | p | p | p | p | p | p |
-| R | p | p | p | p | p | p |
-| S | p | p | p | p | p | p |
-| T | p | p | p | p | p | p |
-| V | h | h | h | h | h | h |
-| **W** | h | h | p | h | h | h |
-| **Y** | h | h | p | h | h | h |
+`hp_lehninger_hpc` is a 3-letter variant: it keeps Lehninger's H/P split for
+every residue except cysteine, which gets its own third symbol `c` (cystine)
+instead of being folded into `h` the way `hp_lehninger_plus_c` does --
+disulfide-bond formation is a distinct chemistry from ordinary hydrophobic
+packing.
+
+| AA | Lehninger (current) | Thomas-Dill/PBotC 2nd | Kyte-Doolittle | TD−C | Leh+C | Leh HPC (3-letter) | PBotC 1st |
+|----|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| A | h | h | h | h | h | h | h |
+| **C** | p | h | h | p | h | c | h |
+| D | p | p | p | p | p | p | p |
+| E | p | p | p | p | p | p | p |
+| F | h | h | h | h | h | h | h |
+| **G** | h | p | p | p | h | h | p |
+| H | p | p | p | p | p | p | p |
+| I | h | h | h | h | h | h | h |
+| K | p | p | p | p | p | p | p |
+| L | h | h | h | h | h | h | h |
+| M | h | h | h | h | h | h | h |
+| N | p | p | p | p | p | p | p |
+| **P** | h | p | p | p | h | h | h |
+| Q | p | p | p | p | p | p | p |
+| R | p | p | p | p | p | p | p |
+| S | p | p | p | p | p | p | p |
+| T | p | p | p | p | p | p | p |
+| V | h | h | h | h | h | h | h |
+| **W** | h | h | p | h | h | h | h |
+| **Y** | h | h | p | h | h | h | h |
 
 ## Using the Builder Pattern
 

--- a/src/rust/encoding.rs
+++ b/src/rust/encoding.rs
@@ -29,7 +29,7 @@ pub fn get_hash_function_from_moltype(moltype: &str) -> Result<HashFunctions, an
         _ => Err(anyhow::anyhow!(
             "Invalid moltype: {}. Supported values: 'protein', 'dayhoff', 'hp', \
              'hp_lehninger', 'hp_thomas_dill', 'hp_kyte_doolittle', \
-             'hp_thomas_dill_no_c', 'hp_lehninger_plus_c', 'hp_lehninger_hpc', 'hp_pbotc_1st_ed', \
+             'hp_thomas_dill_no_c', 'hp_lehninger_c_nonpolar', 'hp_lehninger_hpc', 'hp_pbotc_1st_ed', \
              'hp_shuffled_control', 'hp_shuffled_control_1'..'hp_shuffled_control_10'",
             moltype
         )),

--- a/src/rust/encoding.rs
+++ b/src/rust/encoding.rs
@@ -29,7 +29,7 @@ pub fn get_hash_function_from_moltype(moltype: &str) -> Result<HashFunctions, an
         _ => Err(anyhow::anyhow!(
             "Invalid moltype: {}. Supported values: 'protein', 'dayhoff', 'hp', \
              'hp_lehninger', 'hp_thomas_dill', 'hp_kyte_doolittle', \
-             'hp_thomas_dill_no_c', 'hp_lehninger_plus_c', 'hp_pbotc_1st_ed', \
+             'hp_thomas_dill_no_c', 'hp_lehninger_plus_c', 'hp_lehninger_hpc', 'hp_pbotc_1st_ed', \
              'hp_shuffled_control', 'hp_shuffled_control_1'..'hp_shuffled_control_10'",
             moltype
         )),

--- a/src/rust/hp_alphabets.rs
+++ b/src/rust/hp_alphabets.rs
@@ -18,7 +18,7 @@ pub enum HpAlphabet {
     ThomasDill,
     KyteDoolittle,
     ThomasDillNoC,
-    LehningerPlusC,
+    LehningerCNonpolar,
     LehningerHpc,
     PBotC1stEd,
     ShuffledControl,
@@ -33,7 +33,7 @@ impl HpAlphabet {
             Self::ThomasDill => &THOMAS_DILL_HP,
             Self::KyteDoolittle => &KYTE_DOOLITTLE_HP,
             Self::ThomasDillNoC => &THOMAS_DILL_NO_C_HP,
-            Self::LehningerPlusC => &LEHNINGER_PLUS_C_HP,
+            Self::LehningerCNonpolar => &LEHNINGER_C_NONPOLAR_HP,
             Self::LehningerHpc => &LEHNINGER_HPC,
             Self::PBotC1stEd => &PBOTC_1ST_ED_HP,
             Self::ShuffledControl => &SHUFFLED_CONTROL_HP,
@@ -58,7 +58,7 @@ impl HpAlphabet {
             Self::ThomasDill => "thomas_dill",
             Self::KyteDoolittle => "kyte_doolittle",
             Self::ThomasDillNoC => "thomas_dill_no_c",
-            Self::LehningerPlusC => "lehninger_plus_c",
+            Self::LehningerCNonpolar => "lehninger_c_nonpolar",
             Self::LehningerHpc => "lehninger_hpc",
             Self::PBotC1stEd => "pbotc_1st_ed",
             Self::ShuffledControl => "shuffled_control",
@@ -82,7 +82,7 @@ impl HpAlphabet {
             HpAlphabet::ThomasDill,
             HpAlphabet::KyteDoolittle,
             HpAlphabet::ThomasDillNoC,
-            HpAlphabet::LehningerPlusC,
+            HpAlphabet::LehningerCNonpolar,
             HpAlphabet::LehningerHpc,
             HpAlphabet::PBotC1stEd,
             HpAlphabet::ShuffledControl,
@@ -225,13 +225,13 @@ static THOMAS_DILL_NO_C_HP: LazyLock<HashMap<u8, u8>> =
 //   h: A C F G I L M P V W Y     (11 residues)
 //   p: D E H K N Q R S T         (9 residues)
 // -----------------------------------------------------------------------------
-static LEHNINGER_PLUS_C_HP: LazyLock<HashMap<u8, u8>> =
+static LEHNINGER_C_NONPOLAR_HP: LazyLock<HashMap<u8, u8>> =
     LazyLock::new(|| build_hp(b"ACFGILMPVWY", b"DEHKNQRST"));
 
 // -----------------------------------------------------------------------------
-// Lehninger HPC: 3-letter extension of LehningerPlusC.
+// Lehninger HPC: 3-letter extension of LehningerCNonpolar.
 //
-// LehningerPlusC folds cysteine into the hydrophobic class because its thiol
+// LehningerCNonpolar folds cysteine into the hydrophobic class because its thiol
 // side chain is nonpolar. But cysteine's ability to form disulfide bonds is a
 // distinct chemistry from ordinary hydrophobic packing, so this variant keeps
 // Lehninger's H/P split for the other 19 residues and gives cysteine its own
@@ -373,7 +373,7 @@ mod tests {
             "ThomasDillNoC: C polar by construction"
         );
 
-        // C = hydrophobic in ThomasDill, KyteDoolittle, LehningerPlusC, PBotC1stEd.
+        // C = hydrophobic in ThomasDill, KyteDoolittle, LehningerCNonpolar, PBotC1stEd.
         assert_eq!(
             HpAlphabet::ThomasDill.table()[&b'C'],
             b'h',
@@ -385,9 +385,9 @@ mod tests {
             "KyteDoolittle: C hydrophobic (hydropathy +2.5, Kyte & Doolittle 1982)"
         );
         assert_eq!(
-            HpAlphabet::LehningerPlusC.table()[&b'C'],
+            HpAlphabet::LehningerCNonpolar.table()[&b'C'],
             b'h',
-            "LehningerPlusC: C hydrophobic by construction"
+            "LehningerCNonpolar: C hydrophobic by construction"
         );
         assert_eq!(
             HpAlphabet::PBotC1stEd.table()[&b'C'],
@@ -405,16 +405,16 @@ mod tests {
 
     #[test]
     fn glycine_placement() {
-        // G = hydrophobic in Lehninger (nonpolar aliphatic) and LehningerPlusC.
+        // G = hydrophobic in Lehninger (nonpolar aliphatic) and LehningerCNonpolar.
         assert_eq!(
             HpAlphabet::Lehninger.table()[&b'G'],
             b'h',
             "Lehninger: G nonpolar aliphatic (Nelson & Cox 2021, Ch. 3)"
         );
         assert_eq!(
-            HpAlphabet::LehningerPlusC.table()[&b'G'],
+            HpAlphabet::LehningerCNonpolar.table()[&b'G'],
             b'h',
-            "LehningerPlusC: G inherits Lehninger placement"
+            "LehningerCNonpolar: G inherits Lehninger placement"
         );
         assert_eq!(
             HpAlphabet::LehningerHpc.table()[&b'G'],
@@ -447,16 +447,16 @@ mod tests {
 
     #[test]
     fn proline_placement() {
-        // P = hydrophobic in Lehninger (nonpolar aliphatic), LehningerPlusC, PBotC1stEd.
+        // P = hydrophobic in Lehninger (nonpolar aliphatic), LehningerCNonpolar, PBotC1stEd.
         assert_eq!(
             HpAlphabet::Lehninger.table()[&b'P'],
             b'h',
             "Lehninger: P nonpolar aliphatic (Nelson & Cox 2021, Ch. 3)"
         );
         assert_eq!(
-            HpAlphabet::LehningerPlusC.table()[&b'P'],
+            HpAlphabet::LehningerCNonpolar.table()[&b'P'],
             b'h',
-            "LehningerPlusC: P inherits Lehninger placement"
+            "LehningerCNonpolar: P inherits Lehninger placement"
         );
         assert_eq!(
             HpAlphabet::PBotC1stEd.table()[&b'P'],
@@ -501,7 +501,7 @@ mod tests {
             HpAlphabet::Lehninger,
             HpAlphabet::ThomasDill,
             HpAlphabet::ThomasDillNoC,
-            HpAlphabet::LehningerPlusC,
+            HpAlphabet::LehningerCNonpolar,
             HpAlphabet::LehningerHpc,
             HpAlphabet::PBotC1stEd,
         ] {
@@ -523,7 +523,7 @@ mod tests {
             HpAlphabet::Lehninger,
             HpAlphabet::ThomasDill,
             HpAlphabet::ThomasDillNoC,
-            HpAlphabet::LehningerPlusC,
+            HpAlphabet::LehningerCNonpolar,
             HpAlphabet::LehningerHpc,
             HpAlphabet::PBotC1stEd,
         ] {

--- a/src/rust/hp_alphabets.rs
+++ b/src/rust/hp_alphabets.rs
@@ -19,6 +19,7 @@ pub enum HpAlphabet {
     KyteDoolittle,
     ThomasDillNoC,
     LehningerPlusC,
+    LehningerHpc,
     PBotC1stEd,
     ShuffledControl,
     /// Seeded shuffled control; seed must be 1-10.
@@ -33,6 +34,7 @@ impl HpAlphabet {
             Self::KyteDoolittle => &KYTE_DOOLITTLE_HP,
             Self::ThomasDillNoC => &THOMAS_DILL_NO_C_HP,
             Self::LehningerPlusC => &LEHNINGER_PLUS_C_HP,
+            Self::LehningerHpc => &LEHNINGER_HPC,
             Self::PBotC1stEd => &PBOTC_1ST_ED_HP,
             Self::ShuffledControl => &SHUFFLED_CONTROL_HP,
             Self::Shuffled(1) => &SHUFFLED_HP_1,
@@ -57,6 +59,7 @@ impl HpAlphabet {
             Self::KyteDoolittle => "kyte_doolittle",
             Self::ThomasDillNoC => "thomas_dill_no_c",
             Self::LehningerPlusC => "lehninger_plus_c",
+            Self::LehningerHpc => "lehninger_hpc",
             Self::PBotC1stEd => "pbotc_1st_ed",
             Self::ShuffledControl => "shuffled_control",
             Self::Shuffled(1) => "shuffled_control_1",
@@ -80,6 +83,7 @@ impl HpAlphabet {
             HpAlphabet::KyteDoolittle,
             HpAlphabet::ThomasDillNoC,
             HpAlphabet::LehningerPlusC,
+            HpAlphabet::LehningerHpc,
             HpAlphabet::PBotC1stEd,
             HpAlphabet::ShuffledControl,
         ]
@@ -120,6 +124,26 @@ fn build_hp(h_residues: &[u8], p_residues: &[u8]) -> HashMap<u8, u8> {
     }
     for &r in p_residues {
         m.insert(r, b'p');
+    }
+    m.insert(b'*', b'*'); // stop codon pass-through
+    m
+}
+
+fn build_hpc(h_residues: &[u8], p_residues: &[u8], c_residues: &[u8]) -> HashMap<u8, u8> {
+    assert_eq!(
+        h_residues.len() + p_residues.len() + c_residues.len(),
+        20,
+        "HPC table must cover all 20 canonical amino acids"
+    );
+    let mut m = HashMap::with_capacity(21);
+    for &r in h_residues {
+        m.insert(r, b'h');
+    }
+    for &r in p_residues {
+        m.insert(r, b'p');
+    }
+    for &r in c_residues {
+        m.insert(r, b'c');
     }
     m.insert(b'*', b'*'); // stop codon pass-through
     m
@@ -205,6 +229,22 @@ static LEHNINGER_PLUS_C_HP: LazyLock<HashMap<u8, u8>> =
     LazyLock::new(|| build_hp(b"ACFGILMPVWY", b"DEHKNQRST"));
 
 // -----------------------------------------------------------------------------
+// Lehninger HPC: 3-letter extension of LehningerPlusC.
+//
+// LehningerPlusC folds cysteine into the hydrophobic class because its thiol
+// side chain is nonpolar. But cysteine's ability to form disulfide bonds is a
+// distinct chemistry from ordinary hydrophobic packing, so this variant keeps
+// Lehninger's H/P split for the other 19 residues and gives cysteine its own
+// third symbol ('c', for cystine) instead of merging it into 'h'.
+//
+//   h: A F G I L M P V W Y       (10 residues; = Lehninger's h, C excluded)
+//   p: D E H K N Q R S T         (9 residues; = Lehninger's p, C excluded)
+//   c: C                         (1 residue)
+// -----------------------------------------------------------------------------
+static LEHNINGER_HPC: LazyLock<HashMap<u8, u8>> =
+    LazyLock::new(|| build_hpc(b"AFGILMPVWY", b"DEHKNQRST", b"C"));
+
+// -----------------------------------------------------------------------------
 // Phillips et al. PBotC 1st ed, Figure 8.30.
 // Cys and Tyr are drawn in parentheses in the original figure,
 // indicating borderline H status. We follow the figure's grouping and
@@ -288,12 +328,12 @@ mod tests {
     }
 
     #[test]
-    fn all_mappings_are_h_or_p() {
+    fn all_mappings_are_h_p_or_c() {
         for alpha in all_named_alphabets() {
             for &r in ALL_RESIDUES {
                 let encoded = alpha.table()[&r];
                 assert!(
-                    encoded == b'h' || encoded == b'p',
+                    encoded == b'h' || encoded == b'p' || encoded == b'c',
                     "alphabet {:?} residue {} mapped to unexpected byte {}",
                     alpha,
                     r as char,
@@ -354,6 +394,13 @@ mod tests {
             b'h',
             "PBotC1stEd: C borderline-h (Phillips et al. 2008, Fig. 8.30)"
         );
+
+        // C = its own third class (cystine) in LehningerHpc, distinct from h/p.
+        assert_eq!(
+            HpAlphabet::LehningerHpc.table()[&b'C'],
+            b'c',
+            "LehningerHpc: C is cystine, its own class distinct from h/p"
+        );
     }
 
     #[test]
@@ -368,6 +415,11 @@ mod tests {
             HpAlphabet::LehningerPlusC.table()[&b'G'],
             b'h',
             "LehningerPlusC: G inherits Lehninger placement"
+        );
+        assert_eq!(
+            HpAlphabet::LehningerHpc.table()[&b'G'],
+            b'h',
+            "LehningerHpc: G inherits Lehninger placement"
         );
 
         // G = polar in ThomasDill, KyteDoolittle, ThomasDillNoC, PBotC1stEd.
@@ -411,6 +463,11 @@ mod tests {
             b'h',
             "PBotC1stEd: P hydrophobic (Phillips et al. 2008, Fig. 8.30; moved to p in 2nd ed)"
         );
+        assert_eq!(
+            HpAlphabet::LehningerHpc.table()[&b'P'],
+            b'h',
+            "LehningerHpc: P inherits Lehninger placement"
+        );
 
         // P = polar in ThomasDill, KyteDoolittle, ThomasDillNoC.
         assert_eq!(
@@ -445,6 +502,7 @@ mod tests {
             HpAlphabet::ThomasDill,
             HpAlphabet::ThomasDillNoC,
             HpAlphabet::LehningerPlusC,
+            HpAlphabet::LehningerHpc,
             HpAlphabet::PBotC1stEd,
         ] {
             assert_eq!(alpha.table()[&b'W'], b'h', "{:?}: W hydrophobic (aromatic)", alpha);
@@ -466,6 +524,7 @@ mod tests {
             HpAlphabet::ThomasDill,
             HpAlphabet::ThomasDillNoC,
             HpAlphabet::LehningerPlusC,
+            HpAlphabet::LehningerHpc,
             HpAlphabet::PBotC1stEd,
         ] {
             assert_eq!(alpha.table()[&b'Y'], b'h', "{:?}: Y hydrophobic (aromatic)", alpha);

--- a/src/rust/main.rs
+++ b/src/rust/main.rs
@@ -123,6 +123,9 @@ enum ProteinEncoding {
     /// HP Lehninger with C reassigned to hydrophobic (isolation variant)
     #[value(alias = "hp_lehninger_plus_c")]
     HpLehningerPlusC,
+    /// HPC Lehninger 3-letter: hydrophobic/polar/cystine, C split into its own class
+    #[value(alias = "hp_lehninger_hpc")]
+    HpLehningerHpc,
     /// HP Physical Biology of the Cell 1st ed (Phillips et al. 2008)
     #[value(name = "hp-pbotc-1st-ed", alias = "hp_pbotc_1st_ed")]
     HpPBotC1stEd,
@@ -142,6 +145,7 @@ impl From<ProteinEncoding> for &'static str {
             ProteinEncoding::HpKyteDoolittle => "hp_kyte_doolittle",
             ProteinEncoding::HpThomasDillNoC => "hp_thomas_dill_no_c",
             ProteinEncoding::HpLehningerPlusC => "hp_lehninger_plus_c",
+            ProteinEncoding::HpLehningerHpc => "hp_lehninger_hpc",
             ProteinEncoding::HpPBotC1stEd => "hp_pbotc_1st_ed",
             ProteinEncoding::HpShuffledControl => "hp_shuffled_control",
         }
@@ -564,6 +568,7 @@ fn assign_encoding(
         "hp_kyte_doolittle" => ProteinEncoding::HpKyteDoolittle,
         "hp_thomas_dill_no_c" => ProteinEncoding::HpThomasDillNoC,
         "hp_lehninger_plus_c" => ProteinEncoding::HpLehningerPlusC,
+        "hp_lehninger_hpc" => ProteinEncoding::HpLehningerHpc,
         "hp_pbotc_1st_ed" => ProteinEncoding::HpPBotC1stEd,
         "hp_shuffled_control" => ProteinEncoding::HpShuffledControl,
         // Seeded shuffled controls (hp_shuffled_control_N) are stored with the seed
@@ -575,7 +580,7 @@ fn assign_encoding(
                 message: format!(
                     "Unknown encoding in database: {}. Expected one of: protein, dayhoff, hp, \
                      hp_lehninger, hp_thomas_dill, hp_kyte_doolittle, \
-                     hp_thomas_dill_no_c, hp_lehninger_plus_c, hp_pbotc_1st_ed, \
+                     hp_thomas_dill_no_c, hp_lehninger_plus_c, hp_lehninger_hpc, hp_pbotc_1st_ed, \
                      hp_shuffled_control (or hp_shuffled_control_N for seeded variants)",
                     detected_moltype
                 ),

--- a/src/rust/main.rs
+++ b/src/rust/main.rs
@@ -121,8 +121,8 @@ enum ProteinEncoding {
     #[value(alias = "hp_thomas_dill_no_c")]
     HpThomasDillNoC,
     /// HP Lehninger with C reassigned to hydrophobic (isolation variant)
-    #[value(alias = "hp_lehninger_plus_c")]
-    HpLehningerPlusC,
+    #[value(alias = "hp_lehninger_c_nonpolar")]
+    HpLehningerCNonpolar,
     /// HPC Lehninger 3-letter: hydrophobic/polar/cystine, C split into its own class
     #[value(alias = "hp_lehninger_hpc")]
     HpLehningerHpc,
@@ -144,7 +144,7 @@ impl From<ProteinEncoding> for &'static str {
             ProteinEncoding::HpThomasDill => "hp_thomas_dill",
             ProteinEncoding::HpKyteDoolittle => "hp_kyte_doolittle",
             ProteinEncoding::HpThomasDillNoC => "hp_thomas_dill_no_c",
-            ProteinEncoding::HpLehningerPlusC => "hp_lehninger_plus_c",
+            ProteinEncoding::HpLehningerCNonpolar => "hp_lehninger_c_nonpolar",
             ProteinEncoding::HpLehningerHpc => "hp_lehninger_hpc",
             ProteinEncoding::HpPBotC1stEd => "hp_pbotc_1st_ed",
             ProteinEncoding::HpShuffledControl => "hp_shuffled_control",
@@ -567,7 +567,7 @@ fn assign_encoding(
         "hp_thomas_dill" => ProteinEncoding::HpThomasDill,
         "hp_kyte_doolittle" => ProteinEncoding::HpKyteDoolittle,
         "hp_thomas_dill_no_c" => ProteinEncoding::HpThomasDillNoC,
-        "hp_lehninger_plus_c" => ProteinEncoding::HpLehningerPlusC,
+        "hp_lehninger_c_nonpolar" => ProteinEncoding::HpLehningerCNonpolar,
         "hp_lehninger_hpc" => ProteinEncoding::HpLehningerHpc,
         "hp_pbotc_1st_ed" => ProteinEncoding::HpPBotC1stEd,
         "hp_shuffled_control" => ProteinEncoding::HpShuffledControl,
@@ -580,7 +580,7 @@ fn assign_encoding(
                 message: format!(
                     "Unknown encoding in database: {}. Expected one of: protein, dayhoff, hp, \
                      hp_lehninger, hp_thomas_dill, hp_kyte_doolittle, \
-                     hp_thomas_dill_no_c, hp_lehninger_plus_c, hp_lehninger_hpc, hp_pbotc_1st_ed, \
+                     hp_thomas_dill_no_c, hp_lehninger_c_nonpolar, hp_lehninger_hpc, hp_pbotc_1st_ed, \
                      hp_shuffled_control (or hp_shuffled_control_N for seeded variants)",
                     detected_moltype
                 ),

--- a/src/rust/tests/test_hp_encoding.rs
+++ b/src/rust/tests/test_hp_encoding.rs
@@ -139,7 +139,7 @@ mod tests {
             "hp_thomas_dill",
             "hp_lehninger",
             "hp_thomas_dill_no_c",
-            "hp_lehninger_plus_c",
+            "hp_lehninger_c_nonpolar",
             "hp_lehninger_hpc",
             "hp_pbotc_1st_ed",
         ];

--- a/src/rust/tests/test_hp_encoding.rs
+++ b/src/rust/tests/test_hp_encoding.rs
@@ -140,6 +140,7 @@ mod tests {
             "hp_lehninger",
             "hp_thomas_dill_no_c",
             "hp_lehninger_plus_c",
+            "hp_lehninger_hpc",
             "hp_pbotc_1st_ed",
         ];
 
@@ -171,8 +172,8 @@ mod tests {
                 .unwrap_or_else(|| panic!("{moltype}: encoded_sequence is None (Bug 2)"));
             for ch in enc.chars() {
                 assert!(
-                    ch == 'h' || ch == 'p',
-                    "{moltype}: encoded_sequence char {ch:?} is not h/p (Bug 2 regression)"
+                    ch == 'h' || ch == 'p' || ch == 'c',
+                    "{moltype}: encoded_sequence char {ch:?} is not h/p/c (Bug 2 regression)"
                 );
             }
         }

--- a/src/rust/types.rs
+++ b/src/rust/types.rs
@@ -88,7 +88,7 @@ impl MolType {
             _ => Err(format!(
                 "Invalid molecular type: {}. Must be one of: protein, dayhoff, hp, \
                  hp_lehninger, hp_thomas_dill, hp_kyte_doolittle, \
-                 hp_thomas_dill_no_c, hp_lehninger_plus_c, hp_pbotc_1st_ed, \
+                 hp_thomas_dill_no_c, hp_lehninger_plus_c, hp_lehninger_hpc, hp_pbotc_1st_ed, \
                  hp_shuffled_control",
                 moltype
             )),

--- a/src/rust/types.rs
+++ b/src/rust/types.rs
@@ -88,7 +88,7 @@ impl MolType {
             _ => Err(format!(
                 "Invalid molecular type: {}. Must be one of: protein, dayhoff, hp, \
                  hp_lehninger, hp_thomas_dill, hp_kyte_doolittle, \
-                 hp_thomas_dill_no_c, hp_lehninger_plus_c, hp_lehninger_hpc, hp_pbotc_1st_ed, \
+                 hp_thomas_dill_no_c, hp_lehninger_c_nonpolar, hp_lehninger_hpc, hp_pbotc_1st_ed, \
                  hp_shuffled_control",
                 moltype
             )),


### PR DESCRIPTION
For capturing C2H2 Zinc finger proteins, the cystines have a special role in holding the structure together, so we want to add this alphabet to see if we can detect them well.


Extends hp_lehninger_plus_c by giving cysteine its own symbol ('c') instead of folding it into hydrophobic, since disulfide-bond formation is a distinct chemistry from ordinary hydrophobic packing. Wires the new hp_lehninger_hpc moltype through the CLI, encoding validation, and tests.