### PR TITLE
Fix benchmark.rs calls to search_one after signature change

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -446,7 +446,7 @@ fn benchmark_search_throughput(c: &mut Criterion) {
             {
                 let bench_name = format!("search_one_{moltype}_k{ksize}");
                 c.bench_function(&bench_name, |b| {
-                    b.iter(|| searcher.search_one(&query_sig, &SearchFilters::default()))
+                    b.iter(|| searcher.search_one(&query_sig, &SearchFilters::default(), 1))
                 });
             }
 
@@ -458,7 +458,7 @@ fn benchmark_search_throughput(c: &mut Criterion) {
                     b.iter(|| {
                         queries
                             .iter()
-                            .map(|q| searcher.search_one(q, &SearchFilters::default()))
+                            .map(|q| searcher.search_one(q, &SearchFilters::default(), n_queries))
                             .collect::<Vec<_>>()
                     })
                 });
@@ -527,7 +527,7 @@ fn benchmark_index_hp_large_k(c: &mut Criterion) {
             query_sig.add_protein(&query_seq.1, true).unwrap();
             let search_name = format!("search_one_hp_k{ksize}");
             group.bench_function(&search_name, |b| {
-                b.iter(|| searcher.search_one(&query_sig, &SearchFilters::default()))
+                b.iter(|| searcher.search_one(&query_sig, &SearchFilters::default(), 1))
             });
         }
     }


### PR DESCRIPTION
`ProteinSearcher::search_one` takes `total_queries: usize` as a third argument, but `benches/benchmark.rs` still called it with two. That broke `cargo clippy --no-default-features --all-targets` and `cargo bench` on main.

`total_queries` is the number of query sequences in the run. It does not affect candidate selection or scoring; `compare()` records it on each result as `run_n_queries`. The `joint_kmer_freq` normalization uses the separate `self.total_queries` field set by `set_query_frequencies()`, which the benches never call.

So each call site gets the count of queries that benchmark iteration searches:

- `benches/benchmark.rs:449` — single query, `1`
- `benches/benchmark.rs:461` — batch loop, `n_queries`
- `benches/benchmark.rs:530` — single query, `1`

Verification (`SDKROOT` exported, otherwise librocksdb-sys can't find system headers on macOS):

- `cargo clippy --no-default-features --all-targets` exits 0. Two warnings remain, both pre-existing and unrelated: an `empty_line_after_doc_comments` in the HP-encoding regression tests and a dead-code `CED9_PREFIX` in `src/rust/index.rs`.
- `cargo bench --no-default-features --no-run` builds all four bench targets.
- `cargo fmt -- --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)