### PR TITLE
Disambiguate ALL alphabets

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,11 @@ Total matches: 21
 
 ### Amino acid disambiguation
 
-Three one-letter codes stand for a pair of residues rather than a single one, because the
+Three letters stand for a pair of residues rather than a single one, because the
 method that produced the sequence could not tell the pair apart. Asn and Gln deamidate to
 Asp and Glu during acid hydrolysis, and Ile and Leu have the same mass:
 
-| code | name | stands for |
+| letter | name | stands for |
 |---|---|---|
 | `B` | Asx | `D` (Asp, aspartate) or `N` (Asn, asparagine) |
 | `J` | Xle | `I` (Ile, isoleucine) or `L` (Leu, leucine) |
@@ -306,15 +306,16 @@ Where each k-mer count comes from:
   `hpphp`, `NTAND` and `NBMES` are both `pphpp`. Disambiguating adds none, so it stays
   at 14.
 
-A k-mer may carry at most one ambiguous residue, so disambiguating turns it into two
-k-mers and no more. A k-mer carrying a second is dropped rather than indexed under part of
-its readings, which would make matching depend on which subset was kept.
+Every ambiguous residue in a k-mer expands, so a k-mer carrying *n* of them becomes 2^*n*
+k-mers. Indexing every reading rather than a chosen subset keeps matching from depending on
+which reading was kept.
 
-Capping at one rather than allowing *n* codes and 2^*n* k-mers keeps the index from growing
-on the sequences that inform it least. A k-mer covering several codes comes from a stretch
-the source method could barely read, so most of its readings are guesses about a region
-that was never determined. SwissProt holds about 900 non-canonical residues in 207.6 M, so
-two in one k-mer should be rare.
+The expansion is affordable because ambiguous residues are rare and stay sparse within any one
+window. Swiss-Prot 2026_03 holds 525 of them, 276 `B` and 249 `Z` with no `J` anywhere,
+across 146 of its 575_748 sequences. The densest window in the database holds 9, so the
+worst single k-mer expands to 512 readings, and expansion grows the index by 0.0012% at
+k=4 and 0.034% at k=30. A k-mer carrying more than 16 is dropped, which bounds memory on
+pathological input and which no real sequence approaches.
 
 `U` (Sec, selenocysteine) and `O` (Pyl, pyrrolysine) are handled differently. They are
 specific residues rather than ambiguities, so each takes its closest canonical analogue,

--- a/src/rust/aminoacid.rs
+++ b/src/rust/aminoacid.rs
@@ -9,11 +9,11 @@ pub const STANDARD_AA: [char; 20] = [
     'Y',
 ];
 
-/// Codes that carry no residue identity and so can never be reduced: X (any residue) and
+/// Amino acids that carry no residue identity and so can never be reduced: X (any residue) and
 /// the stop codon.
 pub const SPECIAL_AA: [char; 2] = ['X', '*'];
 
-/// The two residues each ambiguity code stands for.
+/// The two residues each ambiguous residue stands for.
 ///
 ///   - `B` (Asx) is `D` (Asp, aspartate) or `N` (Asn, asparagine)
 ///   - `J` (Xle) is `I` (Ile, isoleucine) or `L` (Leu, leucine)
@@ -22,71 +22,91 @@ pub const SPECIAL_AA: [char; 2] = ['X', '*'];
 /// These appear when the source method could not tell the pair apart, most often because
 /// Asn and Gln deamidate to Asp and Glu during acid hydrolysis.
 ///
-/// A code is never resolved to one of the pair. Every k-mer window covering it is indexed
-/// under *both* readings instead (`disambiguate_kmer`), so a search matches whichever
+/// An ambiguous residue is never resolved to one of the pair. Every k-mer window covering
+/// it is indexed under *both* readings instead (`disambiguate_kmer`), so a search matches whichever
 /// residue the query holds. Picking one would assert a residue the source never
 /// claimed, and which reading is safe depends on the alphabet: SDM12 and HSDM17 give Asp
 /// and Asn separate classes, so under them the two readings are different k-mers.
 pub const AMBIGUITY_ALTERNATIVES: [(char, [char; 2]); 3] =
     [('B', ['D', 'N']), ('J', ['I', 'L']), ('Z', ['E', 'Q'])];
 
-/// The residues `code` stands for, or `None` if it is not an ambiguity code.
-fn alternatives(code: u8) -> Option<[u8; 2]> {
+/// The residues `residue` stands for, or `None` if it is not an ambiguous residue.
+fn alternatives(residue: u8) -> Option<[u8; 2]> {
     AMBIGUITY_ALTERNATIVES
         .iter()
-        .find(|(ambiguity_code, _)| *ambiguity_code as u8 == code)
+        .find(|(ambiguous, _)| *ambiguous as u8 == residue)
         .map(|(_, [first, second])| [*first as u8, *second as u8])
 }
 
-/// Whether `residues` contains any ambiguity code, and so needs disambiguating.
-pub fn has_ambiguity_codes(residues: &[u8]) -> bool {
+/// Whether `residues` contains any ambiguous residue, and so needs disambiguating.
+pub fn has_ambiguous_residues(residues: &[u8]) -> bool {
     residues.iter().any(|b| alternatives(*b).is_some())
 }
 
-/// Disambiguate one k-mer: both readings of its ambiguity code, which is `D` and `N` for
-/// `B`, `I` and `L` for `J`, and `E` and `Q` for `Z`. A k-mer with no ambiguity code
-/// yields itself.
+/// Ceiling on how many ambiguous residues one k-mer may carry before it is dropped rather
+/// than expanded.
 ///
-/// A k-mer carrying a second code is dropped, so disambiguating at most doubles the k-mers
-/// a sequence contributes rather than growing them as `2^n`. The readings past the first
-/// code are also the ones least worth having: a k-mer covering several codes comes from a
-/// stretch the source method could barely read, so its readings are mostly guesses about a
-/// region that was never determined. Dropping it whole rather than indexing part of its
-/// readings keeps matching from depending on which subset was kept, and SwissProt holds
-/// roughly 900 non-canonical residues in 207.6 M, so two in one k-mer should be rare.
+/// This bounds memory; it expresses no view about which readings are worth keeping. `2^n`
+/// readings would otherwise grow without bound on pathological input, such as a long run of
+/// `B`. The densest window in Swiss-Prot 2026_03 holds 9 of them, so no real sequence comes
+/// near this.
+pub const MAX_AMBIGUOUS_RESIDUES_PER_KMER: usize = 16;
+
+/// Disambiguate one k-mer into every reading its ambiguous residues allow: `D` and `N` for
+/// `B`, `I` and `L` for `J`, and `E` and `Q` for `Z`. A k-mer with no ambiguous residue yields
+/// itself; one carrying `n` of them yields all `2^n` readings.
+///
+/// Indexing every reading keeps a search matching whichever residue the query holds, and
+/// keeps matching from depending on which reading was kept. Picking one would assert a
+/// residue the source never claimed, and which reading is safe depends on the alphabet:
+/// SDM12 and HSDM17 give Asp and Asn separate classes, so under them the readings are
+/// different k-mers.
+///
+/// The expansion is affordable because ambiguous residues are rare and stay sparse within
+/// window. Swiss-Prot 2026_03 holds 525 of them, 276 `B` and 249 `Z` with no `J` anywhere,
+/// across 146 of its 575_748 sequences. The densest window holds 9, so the worst single
+/// k-mer expands to 512 readings, and expansion grows the index by 0.0012% at k=4 and
+/// 0.034% at k=30.
 ///
 /// WHY bytes rather than `&str`: callers hash the result, and hashing reads bytes. Going
 /// through `String` would add a UTF-8 validation per reading and a panic path for input
 /// that validation has already ruled out.
 pub fn disambiguate_kmer(kmer: &[u8]) -> Option<Vec<Vec<u8>>> {
-    let mut codes = kmer
+    let ambiguous: Vec<(usize, [u8; 2])> = kmer
         .iter()
         .enumerate()
-        .filter_map(|(position, residue)| alternatives(*residue).map(|pair| (position, pair)));
+        .filter_map(|(position, residue)| alternatives(*residue).map(|pair| (position, pair)))
+        .collect();
 
-    let Some((position, [first, second])) = codes.next() else {
-        return Some(vec![kmer.to_vec()]);
-    };
-    if codes.next().is_some() {
+    if ambiguous.len() > MAX_AMBIGUOUS_RESIDUES_PER_KMER {
         return None;
     }
 
-    let mut with_first = kmer.to_vec();
-    with_first[position] = first;
-    let mut with_second = kmer.to_vec();
-    with_second[position] = second;
-    Some(vec![with_first, with_second])
+    let mut readings = vec![kmer.to_vec()];
+    for (position, [first, second]) in ambiguous {
+        let mut expanded = Vec::with_capacity(readings.len() * 2);
+        for reading in readings {
+            let mut with_second = reading.clone();
+            with_second[position] = second;
+            let mut with_first = reading;
+            with_first[position] = first;
+            expanded.push(with_first);
+            expanded.push(with_second);
+        }
+        readings = expanded;
+    }
+    Some(readings)
 }
 
 /// Non-canonical residues paired with their closest canonical analogue.
 ///
-/// These are specific amino acids, not ambiguity codes, so they carry real chemistry that
+/// These are specific amino acids, not ambiguous residues, so they carry real chemistry that
 /// would otherwise be discarded as unknown. U (Sec, selenocysteine) is cysteine with
 /// selenium in place of sulfur; O (Pyl, pyrrolysine) is a lysine derivative. Each takes
 /// whichever side its analogue takes in the active alphabet.
 pub const NONCANONICAL_AA: [(char, char); 2] = [('U', 'C'), ('O', 'K')];
 
-/// Resolves amino acid codes that are not one of the 20 canonical residues.
+/// Resolves amino acids that are not one of the 20 canonical residues.
 #[derive(Debug, Default)]
 pub struct AminoAcidAmbiguity;
 
@@ -139,7 +159,7 @@ impl AminoAcidAmbiguity {
     /// discarded as unknown. Under `protein20` nothing is substituted, since there is no
     /// class to fall into and rewriting U as C would assert a residue the source never had.
     ///
-    /// The ambiguity codes B, J and Z are never resolved here. They stay in the sequence and
+    /// The ambiguous residues B, J and Z are never resolved here. They stay in the sequence and
     /// every k-mer covering one is indexed under both readings; see `disambiguate_kmer`.
     pub fn validate_and_resolve<'a>(
         &self,
@@ -151,9 +171,10 @@ impl AminoAcidAmbiguity {
         let reduces_alphabet = canonical_moltype(moltype) != "protein20";
 
         // Validate first, recording where the kept region ends and where substitution first
-        // becomes necessary. Almost every sequence needs neither (roughly 900 of SwissProt's
-        // 207.6 M residues are non-canonical), so building an owned copy up front would
-        // allocate and copy once per sequence only to discard it.
+        // becomes necessary. Almost every sequence needs neither (9_066 of Swiss-Prot
+        // 2026_03's 209.0 M residues are non-canonical: 8_181 X, 331 U, 276 B, 249 Z, 29 O
+        // and no J at all), so building an owned copy up front would allocate and copy once
+        // per sequence only to discard it.
         let mut end = sequence.len();
         let mut first_substitution = None;
         for (offset, c) in sequence.char_indices() {
@@ -179,8 +200,8 @@ impl AminoAcidAmbiguity {
             });
         };
 
-        // Reaching here means reduces_alphabet held. Codes with no representative -- X, the
-        // stop codon, and the ambiguity codes, which are expanded at k-mer time instead --
+        // Reaching here means reduces_alphabet held. Amino acids with no representative -- X, the
+        // stop codon, and the ambiguous residues, which are expanded at k-mer time instead --
         // copy through unchanged.
         let mut result = String::with_capacity(kept.len());
         result.push_str(&kept[..start]);
@@ -205,7 +226,7 @@ mod tests {
             assert!(aa.is_valid_aa(*c));
         }
 
-        // Test ambiguous codes
+        // Test ambiguous residues
         assert!(aa.is_valid_aa('B'));
         assert!(aa.is_valid_aa('Z'));
         assert!(aa.is_valid_aa('J'));
@@ -224,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_representative_is_deterministic_and_exact() {
-        // Canonical residues and identity-free codes need no substitution.
+        // Canonical residues, X and the stop codon need no substitution.
         for c in STANDARD_AA.iter() {
             assert_eq!(AminoAcidAmbiguity::representative(*c), None, "{c}");
         }
@@ -295,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_and_resolve_keeps_codes_verbatim_for_protein() {
+    fn test_validate_and_resolve_keeps_ambiguous_residues_verbatim_for_protein() {
         let aa = AminoAcidAmbiguity::new();
 
         // Under protein20 there is no equivalence to exploit, so nothing is substituted.
@@ -352,7 +373,7 @@ mod tests {
         assert_eq!(readings("MKZTA").unwrap(), vec!["MKETA", "MKQTA"]);
     }
 
-    /// A window free of ambiguity codes yields itself, so disambiguation adds no k-mers in
+    /// A window free of ambiguous residues yields itself, so disambiguation adds no k-mers in
     /// the common case.
     #[test]
     fn test_disambiguation_passes_through_unambiguous_kmers() {
@@ -362,23 +383,36 @@ mod tests {
     }
 
     /// Human BCL-2 (UniProt P10415) residues 1-30. The tests below write Asp10 as the
-    /// ambiguity code that stands for it, B, so the real fragment is one of the two
+    /// ambiguous residue that stands for it, B, so the real fragment is one of the two
     /// readings that comes back.
     const BCL2_1_30: &str = "MAHAGRTGYDNREIVMKYIHYKLSQRGYEW";
 
-    /// One code gives two readings, one of which is the real fragment. A second code in the
-    /// same k-mer is refused rather than indexed under an arbitrary subset of its readings.
+    /// Every ambiguous residue in the window expands, so `n` of them give `2^n` readings and the real
+    /// fragment is among them whichever residue the query holds.
     #[test]
-    fn test_one_code_expands_and_a_second_is_refused() {
-        // Residues 1-20 with Asp10 written as B.
+    fn test_every_code_in_the_kmer_expands() {
+        // Residues 1-20 with Asp10 written as B: one ambiguous residue, two readings.
         assert_eq!(
             readings("MAHAGRTGYBNREIVMKYIH").unwrap(),
             vec![&BCL2_1_30[..20], "MAHAGRTGYNNREIVMKYIH"]
         );
-        // The same window with Glu13 also written as Z: two codes, so nothing is indexed.
-        assert_eq!(readings("MAHAGRTGYBNRZIVMKYIH"), None);
-        // Length is not what decides it. Thirty residues with two codes is refused too.
-        assert_eq!(readings("MAHAGRTGYBNRZIVMKYIHYKLSQRGYEW"), None);
+        // The same window with Glu13 also written as Z: two ambiguous residues, so four readings.
+        let two = readings("MAHAGRTGYBNRZIVMKYIH").unwrap();
+        assert_eq!(two.len(), 4);
+        assert!(two.contains(&BCL2_1_30[..20].to_string()), "{two:?}");
+        // Length does not decide it either: the same two ambiguous residues across thirty residues.
+        let longer = readings("MAHAGRTGYBNRZIVMKYIHYKLSQRGYEW").unwrap();
+        assert_eq!(longer.len(), 4);
+        assert!(longer.contains(&BCL2_1_30.to_string()), "{longer:?}");
+    }
+
+    /// The ceiling bounds memory on pathological input. A k-mer past it is dropped whole,
+    /// rather than indexed under an arbitrary subset of its readings.
+    #[test]
+    fn test_kmer_past_the_ceiling_is_dropped() {
+        let at_ceiling = "B".repeat(MAX_AMBIGUOUS_RESIDUES_PER_KMER);
+        assert_eq!(readings(&at_ceiling).unwrap().len(), 1 << MAX_AMBIGUOUS_RESIDUES_PER_KMER);
+        assert_eq!(readings(&"B".repeat(MAX_AMBIGUOUS_RESIDUES_PER_KMER + 1)), None);
     }
 
     /// Every reading must be a sequence over the canonical residues, since each stands for a

--- a/src/rust/index.rs
+++ b/src/rust/index.rs
@@ -1630,7 +1630,7 @@ impl ProteomeIndex {
     /// to extract detailed position information, and returns the signature for later storage.
     ///
     /// The method resolves amino acid ambiguity before processing. Valid amino acids include the 20 standard amino acids (A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y)
-    /// and the ambiguous codes (B for D/N, Z for E/Q, J for I/L, X for unknown) which are resolved to one of their possible values.
+    /// and the ambiguous residues (B for D/N, Z for E/Q, J for I/L, X for unknown) which are resolved to one of their possible values.
     ///
     /// # Arguments
     ///
@@ -3198,13 +3198,13 @@ mod tests {
             false,
         )?;
 
-        // The k-mer count is the number of *readings*, not the number of windows: an
-        // ambiguity code doubles the windows covering it, and a window carrying a second
-        // code is dropped. For "ACDEFXBZJ" the five windows ACDEF, CDEFX, DEFXB, EFXBZ and
-        // FXBZJ carry 0, 0, 1, 2 and 3 codes, so the first three give 1 + 1 + 2 = 4
-        // readings and the last two are dropped.
+        // The k-mer count is the number of *readings*, not the number of windows: every
+        // ambiguous residue in a window doubles it, so a window carrying n of them gives 2^n
+        // readings. For "ACDEFXBZJ" the five windows ACDEF, CDEFX, DEFXB, EFXBZ and FXBZJ
+        // carry 0, 0, 1, 2 and 3 of them, so they give 1 + 1 + 2 + 4 + 8 = 16 readings. X is
+        // not an ambiguous residue and never expands.
         let valid_sequences =
-            [("PLANTANDANIMALGENQMES", 17), ("ACDEFGHIKLMNPQRSTVWY", 16), ("ACDEFXBZJ", 4)];
+            [("PLANTANDANIMALGENQMES", 17), ("ACDEFGHIKLMNPQRSTVWY", 16), ("ACDEFXBZJ", 16)];
 
         for (sequence, expected_kmers) in valid_sequences {
             let protein_signature = index.create_protein_signature(sequence, "test_protein")?;
@@ -3231,7 +3231,7 @@ mod tests {
             );
         }
 
-        // Ambiguity codes are accepted, and indexed under both readings rather than one.
+        // Ambiguous residues are accepted, and indexed under both readings rather than one.
         let ambiguous_sequences = [
             ("PLANTANDANIMALGENBMES", 21), // B is indexed as both Asp and Asn
             ("PLANTANDANIMALGENZMES", 21), // Z is indexed as both Glu and Gln
@@ -3253,7 +3253,7 @@ mod tests {
             assert_eq!(
                 protein_signature.kmer_positions().len(),
                 expected_kmers,
-                "{sequence}: expected the windows covering the ambiguity code to be doubled"
+                "{sequence}: expected the windows covering the ambiguous residue to be doubled"
             );
         }
 
@@ -3276,7 +3276,7 @@ mod tests {
             false,
         )?;
 
-        // Ambiguity codes are accepted, and indexed under both readings rather than one.
+        // Ambiguous residues are accepted, and indexed under both readings rather than one.
         let ambiguous_sequences = [
             ("PLANTANDANIMALGENBMES", 17), // Asp and Asn are both dayhoff `c`
             ("PLANTANDANIMALGENZMES", 17), // Glu and Gln are both dayhoff `c`
@@ -3292,7 +3292,7 @@ mod tests {
             );
 
             let protein_signature = result.unwrap();
-            // Disambiguating a code adds k-mers only where the alphabet keeps the two readings
+            // Disambiguating adds k-mers only where the alphabet keeps the two readings
             // apart. Dayhoff puts both members of every ambiguous pair in one class, so the
             // disambiguated windows hash identically and the count is unchanged.
             assert_eq!(protein_signature.kmer_positions().len(), expected_kmers, "{sequence}");
@@ -3340,7 +3340,7 @@ mod tests {
             false,
         )?;
 
-        // Ambiguity codes are accepted, and indexed under both readings rather than one.
+        // Ambiguous residues are accepted, and indexed under both readings rather than one.
         let ambiguous_sequences = [
             ("PLANTANDANIMALGENBMES", 14), // Asp and Asn are both polar
             ("PLANTANDANIMALGENZMES", 14), // Glu and Gln are both polar
@@ -3608,18 +3608,18 @@ mod tests {
     }
 
     /// Real N-terminal fragment of C. elegans CED-9 (UniProt P41958) with three residues
-    /// rewritten to the ambiguity codes that stand for them: Asn->B (Asx), Glu->Z (Glx),
+    /// rewritten to the ambiguous residues that stand for them: Asn->B (Asx), Glu->Z (Glx),
     /// Ile->J (Xle). Also carries U (Sec) and O (Pyl).
-    const CED9_WITH_AMBIGUITY_CODES: &str =
+    const CED9_WITH_AMBIGUOUS_RESIDUES: &str =
         "MTRCTADNSLTNPAYRRRTMBTGEMKEFLGJKGTEPTDFGZNSDAQDLPSPSRQASTRRUO";
 
     /// Indexing the same sequence twice must produce byte-identical sketches.
     ///
-    /// WHY: ambiguity codes were previously resolved by drawing at random from the
+    /// WHY: ambiguous residues were previously resolved by drawing at random from the
     /// alternatives, so B became Asp on one run and Asn on the next. That changed the k-mers,
     /// the hashes and the stored index every time the same FASTA was indexed.
     #[test]
-    fn test_ambiguity_codes_index_deterministically() {
+    fn test_ambiguous_residues_index_deterministically() {
         let temp_dir = tempdir().unwrap();
 
         for (i, moltype) in
@@ -3630,14 +3630,14 @@ mod tests {
                     .unwrap();
 
             let first = index
-                .create_protein_signature(CED9_WITH_AMBIGUITY_CODES, "ced9")
+                .create_protein_signature(CED9_WITH_AMBIGUOUS_RESIDUES, "ced9")
                 .unwrap()
                 .mins_as_set();
             assert!(!first.is_empty(), "{moltype}: no k-mers produced");
 
             for attempt in 0..5 {
                 let again = index
-                    .create_protein_signature(CED9_WITH_AMBIGUITY_CODES, "ced9")
+                    .create_protein_signature(CED9_WITH_AMBIGUOUS_RESIDUES, "ced9")
                     .unwrap()
                     .mins_as_set();
                 assert_eq!(again, first, "{moltype}: sketch differed on attempt {attempt}");

--- a/src/rust/sketch.rs
+++ b/src/rust/sketch.rs
@@ -399,7 +399,7 @@ impl ProteinSketch {
     /// search speed (O(1) lookup in find_matched_regions).
     pub fn add_protein(&mut self, sequence: &str, store_sequences: bool) -> anyhow::Result<()> {
         use crate::alphabets::alphabet_table;
-        use crate::aminoacid::{disambiguate_kmer, has_ambiguity_codes};
+        use crate::aminoacid::{disambiguate_kmer, has_ambiguous_residues};
         use crate::hash_functions::{
             encode_by_alphabet, encode_with_fn, get_encoding_fn_from_moltype,
         };
@@ -423,7 +423,7 @@ impl ProteinSketch {
         // delegating to sourmash's black-box `add_protein`, which windows and
         // inserts unconditionally. `remove_low_complexity` defaults to false,
         // and the branch below keeps every k-mer.
-        if has_ambiguity_codes(sequence.as_bytes()) && !self.remove_low_complexity {
+        if has_ambiguous_residues(sequence.as_bytes()) && !self.remove_low_complexity {
             // B, J and Z each stand for two residues (B is Asp or Asn, J is Ile or Leu, Z
             // is Glu or Gln). Rather than committing to one, index every window under both
             // readings, so a query carrying either residue matches.
@@ -436,7 +436,7 @@ impl ProteinSketch {
             let mut scratch = Vec::with_capacity(ksize);
             for i in 0..residues.len().saturating_sub(ksize - 1) {
                 let kmer = &residues[i..i + ksize];
-                if !has_ambiguity_codes(kmer) {
+                if !has_ambiguous_residues(kmer) {
                     let hashval = Self::hash_kmer(kmer, residue_classes, encoding_fn, &mut scratch);
                     self.signature.minhash.add_hash(hashval);
                     continue;
@@ -517,16 +517,16 @@ impl ProteinSketch {
 
         let encoding_fn = get_encoding_fn_from_moltype(&moltype_str)?;
         let residues = sequence.as_bytes();
-        // Checked once for the whole sequence: almost none carry an ambiguity code (roughly
+        // Checked once for the whole sequence: almost none carry an ambiguous residue (roughly
         // 900 non-canonical residues in SwissProt's 207.6 M), so the per-window check is
         // skipped entirely for nearly every sequence.
-        let sequence_has_codes = has_ambiguity_codes(residues);
+        let sequence_has_ambiguous_residues = has_ambiguous_residues(residues);
         // Reused across windows. Without it this loop allocated once per window, and once
         // per reading, for every sequence indexed.
         let mut scratch = Vec::with_capacity(ksize);
         for i in 0..residues.len().saturating_sub(ksize - 1) {
             let kmer = &residues[i..i + ksize];
-            if !sequence_has_codes || !has_ambiguity_codes(kmer) {
+            if !sequence_has_ambiguous_residues || !has_ambiguous_residues(kmer) {
                 let hashval = Self::hash_kmer(kmer, residue_classes, encoding_fn, &mut scratch);
                 if hashvals.contains(&hashval) {
                     self.kmer_positions_mut().entry(hashval).or_default().push(i);


### PR DESCRIPTION
Olga: While the number of B/Z residues make up <0.01% of UniRef50, it's still 12,409 proteins that are totally ignored. Similarly, AlphFold ignores ALL nonstandard amino acids, including [Pyrrolysine](https://en.wikipedia.org/wiki/Pyrrolysine) (O) and [Selenocysteine](https://en.wikipedia.org/wiki/Selenocysteine) (U), which is 249,823 UniRef50 representatives standing for almost 1 million member proteins! Again, not even 1% of UniRef50, but still worth including in my opinion!

<h3 dir="ltr">UniRef50 2026_03, full scan</h3><p dir="ltr">38_840_027 clusters, 244_028_969 member proteins.</p><div dir="ltr"><div>

if we ignored... | clusters | member proteins | share of UniRef50
-- | -- | -- | --
ambiguous residues (B/J/Z) | 1_982 | 12_409 | 0.0051%
— of those, reps with ≥2 ambiguous residues, which the old cap dropped at k=10 | 343 | 1_898 | 0.0009%
everything AlphaFold skips (B/J/Z/X/U/O) | 249_823 | 939_826 | 0.64% / 0.39%

Interestingly, even *representative* sequences in [UniRef50/90/100 ](https://www.uniprot.org/help/uniref) have ambiguous codes! Which means that these sequences are completely unrepresented in structural databases like AlphaFoldDB, as their codes are ignored.

<p dir="ltr">Distribution of ambiguous residues in the representative:</p><div dir="ltr"><div>

ambiguous | clusters | proteins
-- | -- | --
1 | 1_639 | 10_511
2 | 239 | 1_040
3 | 64 | 252
4 | 15 | 398
5–9 | 18 | 40
10–22 | 6 | 167

</div></div><p dir="ltr">Cumulatively: 343 clusters with ≥2, 104 with ≥3, 25 with ≥5, 6 with ≥10.</p>

This PR expands ALL ambiguous `B`/`J`/`Z` residues and adds two k-mers for each. e.g. for `J` -> add both k-mers with `L` (Leucine) and `I` (isoleucine) in all positions. The worst it can get is 22 ambiguous residues in a protein, which is a lot but still countably many.

This affects 9/19 alphabets, almost all the alphabets with >3 classes:

<div dir="ltr"><div>
alphabet | size | B (D vs N) | J (I vs L) | Z (E vs Q)
-- | -- | -- | -- | --
polarity4 | 4 | ≠ | = | ≠
wwmj5 | 5 | ≠ | = | ≠
funcgroups8 | 8 | ≠ | = | ≠
sdm12 | 12 | ≠ | = | ≠
mmseqs12 | 12 | = | ≠ | =
wass14 | 14 | ≠ | ≠ | ≠
hsdm17 | 17 | ≠ | = | ≠
uniprot18 | 18 | ≠ | ≠ | ≠
protein20 | 20 | ≠ | ≠ | ≠

</div></div><p dir="ltr"></p>




---
The member-protein column counts every protein in a cluster whose *representative* carries the
residue. The other members are ordinary proteins that AlphaFold does model, so 939_826 is the
sequence space unreachable through the representative, not a count of proteins AlphaFold skips.
That count, for this analysis, is the 249_823 representatives themselves.

## Expand every ambiguous residue in a k-mer

`B`, `J` and `Z` each stand for two residues, and kmerseek indexes a k-mer covering one under
both readings rather than picking one. A k-mer covering *n* of them is now indexed under all 2^*n*
readings. The cap was `ceil(ksize / 10)` of them and k-mers past it were dropped, so at the default
`--ksize 10` a k-mer holding two contributed nothing.

A dropped k-mer is a hole in the index rather than a saving. The sequences it drops are the ones
that need the index most: a protein sequenced by Edman degradation or acid hydrolysis carries runs
of B and Z, has no AlphaFold model, and so has no structural route to a homolog either. Indexing
all 2^*n* readings keeps those stretches searchable.

X, U and O are unchanged. X passes through as itself, and U and O still take their canonical
analogue (C and K) under a reduced alphabet.

### What it costs

The worst real case is [sp|P00659|RNAS1_DAMKO](https://www.uniprot.org/uniprotkb/P00659/entry),
a pancreatic RNase from [Damaliscus korrigum](https://en.wikipedia.org/wiki/Korrigum), with 22 Bs
and Zs:

```
>sp|P00659|RNAS1_DAMKO Ribonuclease pancreatic OS=Damaliscus korrigum OX=9930 GN=RNASE1 PE=1 SV=1
KESAAAKFZRZHMBSSTSSASSSBYCBZMMKSRNLTQDRCKPVBTFVHZSLABVZAVCSZ
KBVACKBGZTBCYZSYSTMSITBCRZTGSSKYPBCAYKTTQAKKHIIVACZGBPYVPVHF
BASV
```

2^22 is the wrong bound. The 22 are spread across 124 positions, so no window of 30 or fewer
holds more than 9 of them:

| k | most ambiguous residues in one window | readings from that window | readings for the whole sequence |
|---:|---:|---:|---:|
| 10 | 4 | 16 | 541 |
| 16 | 6 | 64 | 1_241 |
| 20 | 7 | 128 | 2_352 |
| 25 | 8 | 256 | 5_092 |
| 30 | 9 | 512 | 10_360 |

Sequences this dense are rare: 6 UniRef50 representatives in 38.8 M hold 10 or more.

## Verification

- The expansion counts above were computed from the P00659 sequence directly, as a check on what
  the index should produce.
- `ACDEFXBZJ` at k=5 yields 16 k-mers: the five windows hold 0, 0, 1, 2 and 3 of them, so
  1 + 1 + 2 + 4 + 8. It was 4 under the old cap, which dropped the last three windows.
- Searching CED-9 against the 25-sequence BCL-2 fixture is unchanged, since that fixture carries
  no ambiguous residues.
- 233 tests pass, `cargo fmt --check` clean, zero clippy warnings.

## Relationship to #46

#46 carried this description but merged the earlier code, which allowed at most one ambiguous
residue per k-mer and dropped any window holding two. This is the implementation the description
argues for. It also renames the terminology: B, J and Z are ambiguous residues throughout, in
prose and in identifiers, rather than "ambiguity codes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

